### PR TITLE
[Feat, Design] 무한 스크롤, 카테고리별 검색 결과, 카드 UI 구현

### DIFF
--- a/components/collected-card.tsx
+++ b/components/collected-card.tsx
@@ -1,0 +1,29 @@
+import { Card, Typography } from '@material-tailwind/react';
+
+export default function CollectedCard({ name, address, phone, ratings }) {
+  return (
+    <Card className="h-40">
+      <Typography variant="h5" color="blue-gray" className="">
+        {name}
+      </Typography>
+      <div className="flex justify-center">
+        <img
+          src="https://cdn.gukjenews.com/news/photo/202404/2977498_3052518_4331.png"
+          alt="cafe_img"
+          width={100}
+        />
+      </div>
+      <div className="flex justify-end">
+        {Array(ratings)
+          .fill(0)
+          .map((_, index) => (
+            <i key={index} className="fa-solid fa-star text-yellow-700"></i>
+          ))}
+      </div>
+      <div className="flex flex-col">
+        <Typography>{address}</Typography>
+        <Typography>{phone}</Typography>
+      </div>
+    </Card>
+  );
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -3,8 +3,7 @@ import LogoutButton from './logout-button';
 
 export default function Footer({ session }) {
   return (
-    <div className="flex flex-col gap-2 items-center">
-      <Profile session={session} />
+    <div className="flex justify-center items-center">
       <LogoutButton />
     </div>
   );

--- a/components/normal-card.tsx
+++ b/components/normal-card.tsx
@@ -1,0 +1,29 @@
+import { Card, Typography } from '@material-tailwind/react';
+
+export default function NormalCard({ name, address, phone, ratings }) {
+  return (
+    <Card className="h-40">
+      <Typography variant="h5" color="blue-gray" className="">
+        {name}
+      </Typography>
+      <div className="flex justify-center">
+        <img
+          src="https://cdn.gukjenews.com/news/photo/202404/2977498_3052518_4331.png"
+          alt="cafe_img"
+          width={100}
+        />
+      </div>
+      <div className="flex justify-end">
+        {Array(ratings)
+          .fill(0)
+          .map((_, index) => (
+            <i key={index} className="fa-solid fa-star text-yellow-700"></i>
+          ))}
+      </div>
+      <div className="flex flex-col">
+        <Typography>{address}</Typography>
+        <Typography>{phone}</Typography>
+      </div>
+    </Card>
+  );
+}

--- a/components/profile.tsx
+++ b/components/profile.tsx
@@ -10,12 +10,12 @@ export default function Profile({ session }) {
         alt="avatar"
         className="relative inline-block object-cover object-center w-12 h-12 rounded-lg"
       />
-      <div>
+      <div className="flex gap-1">
         <h6 className="text-slate-800 font-semibold">
           {session?.user?.email?.split('@')?.[0]}
         </h6>
+        <Badge tier={'expert'} />
       </div>
-      <Badge tier={'expert'} />
     </div>
   );
 }

--- a/components/search.tsx
+++ b/components/search.tsx
@@ -9,7 +9,13 @@ export default function Search() {
 
   const handleSearch = () => {
     setKeyword(localKeyword);
-    router.push('/search');
+    router.push('/cafe/all');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSearch(); // Enter 키를 눌렀을 때 검색 이벤트 실행
+    }
   };
 
   return (
@@ -21,6 +27,7 @@ export default function Search() {
             placeholder="어떤 카페를 찾을까요?"
             value={localKeyword}
             onChange={(e) => setLocalKeyword(e.target.value)}
+            onKeyDown={handleKeyDown}
           />
           <button
             className="absolute top-1 right-1 flex items-center gap-1 rounded bg-main py-1 px-2.5 border border-transparent text-center text-sm text-white transition-all shadow-sm hover:shadow focus:bg-slate-700 focus:shadow-none active:bg-slate-700 hover:bg-purple-300 active:shadow-none disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none"

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,13 +1,18 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMapStore } from 'utils/store';
 import { usePathname, useRouter } from 'next/navigation';
+import { useInView } from 'react-intersection-observer';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { Card, List, ListItem, ListItemPrefix } from '@material-tailwind/react';
 import Header from './header';
 import Search from './search';
 import Footer from './footer';
 import SubSidebar from './sub-sidebar';
+import NormalCard from './normal-card';
+import CollectedCard from './collected-card';
+import Profile from './profile';
 
 function MainItem({ icon, title, path }) {
   return (
@@ -20,15 +25,39 @@ function MainItem({ icon, title, path }) {
 
 export default function Sidebar({ session }) {
   const [isSubSidebarOpen, setIsSubSidebarOpen] = useState(false);
+  const { ref, inView } = useInView({ threshold: 0 });
   const router = useRouter();
   const pathname = usePathname();
   const results = useMapStore((state) => state.results);
 
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      initialPageParam: 0,
+      queryKey: ['results'],
+      queryFn: ({ pageParam = 0 }) => {
+        const start = pageParam * 6;
+        return {
+          data: results.slice(start, start + 6),
+          page: pageParam,
+        };
+      },
+      getNextPageParam: (lastPage) => {
+        const nextPage = lastPage.page + 1;
+        return lastPage.data.length === 6 ? nextPage : null;
+      },
+    });
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, fetchNextPage]);
+
   return (
     <div className="relative flex items-center">
       {/* 메인 사이드바 */}
-      <Card className="h-[100vh] w-full max-w-[20rem] p-6 rounded-none shadow-xl shadow-mainShadow flex flex-col justify-between z-10 relative">
-        <div>
+      <Card className="h-[100vh] max-h-screen w-full max-w-[20rem] p-6 rounded-none shadow-xl shadow-mainShadow flex flex-col justify-between z-10 relative overflow-y-scroll">
+        <div className="flex flex-col gap-4">
           <Header
             img={
               'https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/f21a74a1-65e0-4c8b-9b4f-80db3b5bbddb/d4gayid-ebc15d60-9420-4cbc-9680-d57650f89091.png/v1/fill/w_900,h_675/yu_gi_oh_5d_s_logo_render_by_nyaediter_d4gayid-fullview.png?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7ImhlaWdodCI6Ijw9Njc1IiwicGF0aCI6IlwvZlwvZjIxYTc0YTEtNjVlMC00YzhiLTliNGYtODBkYjNiNWJiZGRiXC9kNGdheWlkLWViYzE1ZDYwLTk0MjAtNGNiYy05NjgwLWQ1NzY1MGY4OTA5MS5wbmciLCJ3aWR0aCI6Ijw9OTAwIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmltYWdlLm9wZXJhdGlvbnMiXX0.KFzCdQb27TuUOrcgKc7x28oQM3T7QZ9oihSVWAnxjPc'
@@ -61,55 +90,55 @@ export default function Sidebar({ session }) {
             </List>
           )}
 
-          {/* 검색 결과 */}
-          {pathname === '/search' && (
-            <div>
-              {results.length > 0 && (
-                <div>
-                  <ul>
-                    {results.slice(0, 6).map(
-                      (
-                        result,
-                        index // 처음 6개의 결과만 표시
-                      ) => (
-                        <li key={index} className="mb-2 p-2 border-b">
-                          <h3 className="text-lg font-semibold">
-                            {result.place_name}
-                          </h3>
-                          <p>{result.address_name}</p>
-                          <p>{result.phone}</p>
-                        </li>
-                      )
-                    )}
-                  </ul>
-                  <button onClick={() => router.push('/')}>홈으로 가기</button>
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* 모든 카페 보기 */}
+          {/* 기본 검색 결과 = 모든 카페 보기 */}
           {pathname === '/cafe/all' && (
             <div>
-              <button onClick={() => router.push('/')}>홈으로 가기</button>
+              {data?.pages?.map((page, i) => (
+                <div key={i} className="flex flex-col gap-4">
+                  {page.data.map((cafe, index) => (
+                    <NormalCard
+                      name={cafe.place_name}
+                      ratings={10}
+                      address={cafe.address_name}
+                      phone={cafe.phone}
+                    />
+                  ))}
+                </div>
+              ))}
             </div>
           )}
 
           {/* 수집한 카페 보기 */}
           {pathname === '/cafe/collected' && (
-            <div>
-              <button onClick={() => router.push('/')}>홈으로 가기</button>
-            </div>
+            <CollectedCard
+              name={'인더매스'}
+              ratings={10}
+              address={'대구 삼덕동'}
+              phone={'053-0000-0000'}
+            />
           )}
 
           {/* 안 가본 카페만 따로 보기 */}
-          {pathname === '/cafe/not-collected' && (
-            <div>
-              <button onClick={() => router.push('/')}>홈으로 가기</button>
-            </div>
+          {pathname === '/cafe/not-collected' && <div></div>}
+
+          {/* 무한 스크롤 로딩 */}
+          {isFetchingNextPage && (
+            <div className="text-center py-2">로딩 중...</div>
           )}
+          <div ref={ref}></div>
         </div>
-        <Footer session={session} />
+        <div className="flex flex-col gap-1">
+          <button
+            className="w-30 p-1 border-solid border-2 border-main"
+            onClick={() => router.push('/')}
+          >
+            Home
+          </button>
+          <div className={`${pathname === '/' ? 'opacity-100' : 'opacity-0'}`}>
+            <Profile session={session} />
+          </div>
+          <Footer session={session} />
+        </div>
       </Card>
 
       {/* 서브 사이드바 */}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev && open http://localhost:3000",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -1,2 +1,3 @@
 declare module '@material-tailwind/react';
 declare module 'zustand';
+declare module '@tanstack/react-query';

--- a/utils/store.ts
+++ b/utils/store.ts
@@ -2,11 +2,13 @@ import { create } from 'zustand';
 
 interface MapState {
   keyword: string;
+  results: any[];
   setKeyword: (keyword: string) => void;
+  setResults: (results: any[]) => void;
 }
 
 export const useMapStore = create((set) => ({
-  keyword: '',
+  keyword: '성수동 카페',
   results: [],
   setKeyword: (keyword) => set({ keyword }),
   setResults: (results) => set({ results }),


### PR DESCRIPTION
<h2>무한 스크롤 구현</h2>
useInfiniteQuery를 사용하여 무한 스크롤 구현
하지만 현재 윈도우 포커스를 다시 해야 리스트에 다음 페이지가 업데이트 추가되는 버그가 있음 -> 해결 필요

<h2>카테고리별 검색 결과</h2>
검색창에서 키워드로 검색하면 '카페' 카테고리의 장소만 지도상에 표시되고 사이드바에 리스트로 나오도록 함

<h2>카드 UI 구현</h2>
모든 카페 normal-card
수집한 카페 collected-card