### PR TITLE
4 commits

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -62,7 +62,7 @@ export default async function RootLayout({
         <ReactQueryClientProvider>
           <AuthProvider accessToken={session?.access_token}>
             {session?.user ? (
-              <MainLayout session={session}>
+              <MainLayout>
                 {children}
                 <KakaoMap />
                 <ToastContainer

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,3 @@
-export default function Home() {
+export default function HomePage() {
   return null;
 }

--- a/app/resetpassword/complete/page.tsx
+++ b/app/resetpassword/complete/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { createBrowserSupabaseClient } from 'utils/supabase/client';
+import { Card } from '@mui/material';
+import Image from 'next/image';
+
+export default function ResetPasswordCompletePage() {
+  const supabase = createBrowserSupabaseClient();
+
+  const handleRoute = async () => {
+    await supabase.auth.signOut();
+    window.close();
+  };
+
+  return (
+    <main className="area h-screen w-screen flex justify-center items-center">
+      <ul className="circles z-0">
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+      </ul>
+      <div className="flex flex-col items-center gap-4">
+        <Image
+          alt="텍스트 로고"
+          src="https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters/logo_text.webp"
+          width={180}
+          height={180}
+          className="w-auto h-auto"
+        />
+        <Card className="z-10 p-5 rounded-xl bg-white shadow-mainShadow">
+          <div className="w-80 max-w-screen-lg sm:w-96 flex flex-col gap-4">
+            <p className="text-center text-3xl font-bold font-dpixel">
+              비밀번호 재설정 완료
+            </p>
+            <span>초기 화면으로 돌아가 다시 로그인하세요!</span>
+            <button className="bg-main text-white w-full" onClick={handleRoute}>
+              돌아가기
+            </button>
+          </div>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/app/resetpassword/complete/page.tsx
+++ b/app/resetpassword/complete/page.tsx
@@ -3,6 +3,8 @@
 import { createBrowserSupabaseClient } from 'utils/supabase/client';
 import { Card } from '@mui/material';
 import Image from 'next/image';
+import Head from 'next/head';
+import AuthBackgroundCards from 'components/auth/auth-background-cards';
 
 export default function ResetPasswordCompletePage() {
   const supabase = createBrowserSupabaseClient();
@@ -13,39 +15,43 @@ export default function ResetPasswordCompletePage() {
   };
 
   return (
-    <main className="area h-screen w-screen flex justify-center items-center">
-      <ul className="circles z-0">
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-      </ul>
-      <div className="flex flex-col items-center gap-4">
-        <Image
-          alt="텍스트 로고"
-          src="https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters/logo_text.webp"
-          width={180}
-          height={180}
-          className="w-auto h-auto"
+    <>
+      <Head>
+        <title>비밀번호 재설정 완료 | Cafe Masters</title>
+        <meta
+          name="description"
+          content={`비밀번호 재설정을 완료했으니, 다시 로그인해보세요.`}
         />
-        <Card className="z-10 p-5 rounded-xl bg-white shadow-mainShadow">
-          <div className="w-80 max-w-screen-lg sm:w-96 flex flex-col gap-4">
-            <p className="text-center text-3xl font-bold font-dpixel">
-              비밀번호 재설정 완료
-            </p>
-            <span>초기 화면으로 돌아가 다시 로그인하세요!</span>
-            <button className="bg-main text-white w-full" onClick={handleRoute}>
-              돌아가기
-            </button>
-          </div>
-        </Card>
-      </div>
-    </main>
+      </Head>
+      <main className="area h-screen w-screen flex justify-center items-center">
+        <AuthBackgroundCards />
+        <div className="flex flex-col items-center gap-4">
+          <Image
+            alt="텍스트 로고"
+            src="https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters/logo_text.webp"
+            width={180}
+            height={180}
+            className="w-auto h-auto"
+          />
+          <Card className="z-10 p-5 rounded-xl bg-white shadow-mainShadow">
+            <div className="w-80 max-w-screen-lg sm:w-96 flex flex-col gap-4">
+              <p className="text-center text-3xl font-bold font-dpixel">
+                비밀번호 재설정 완료
+              </p>
+              <span className="text-lg font-dpixel">
+                초기 화면으로 돌아가 다시 로그인하세요!
+              </span>
+              <button
+                className="bg-main w-full hover:bg-opacity-70 hover:cursor-pointer"
+                onClick={handleRoute}
+                aria-label="돌아가기 버튼, 초기 화면으로 돌아갑니다."
+              >
+                <span className="text-white font-dpixel">돌아가기</span>
+              </button>
+            </div>
+          </Card>
+        </div>
+      </main>
+    </>
   );
 }

--- a/app/resetpassword/complete/page.tsx
+++ b/app/resetpassword/complete/page.tsx
@@ -9,7 +9,7 @@ import AuthBackgroundCards from 'components/auth/auth-background-cards';
 export default function ResetPasswordCompletePage() {
   const supabase = createBrowserSupabaseClient();
 
-  const handleRoute = async () => {
+  const handleWindow = async () => {
     await supabase.auth.signOut();
     window.close();
   };
@@ -43,7 +43,7 @@ export default function ResetPasswordCompletePage() {
               </span>
               <button
                 className="bg-main w-full hover:bg-opacity-70 hover:cursor-pointer"
-                onClick={handleRoute}
+                onClick={handleWindow}
                 aria-label="돌아가기 버튼, 초기 화면으로 돌아갑니다."
               >
                 <span className="text-white font-dpixel">돌아가기</span>

--- a/app/resetpassword/page.tsx
+++ b/app/resetpassword/page.tsx
@@ -35,6 +35,8 @@ export default function ResetpasswordPage() {
     },
   });
 
+  const textStyle = `font-dpixel text-lg`;
+
   return (
     <>
       <Head>
@@ -57,7 +59,7 @@ export default function ResetpasswordPage() {
                 비밀번호 재설정
               </p>
               <div className="flex gap-4 justify-between items-center">
-                <span className="font-dpixel text-lg">새 비밀번호</span>
+                <span className={textStyle}>새 비밀번호</span>
                 <input
                   type="password"
                   value={newPassword}
@@ -67,7 +69,7 @@ export default function ResetpasswordPage() {
                 />
               </div>
               <div className="flex gap-4 justify-between items-center">
-                <span className="font-dpixel text-lg">비밀번호 확인</span>
+                <span className={textStyle}>비밀번호 확인</span>
                 <input
                   type="password"
                   value={newPasswordConfirm}
@@ -82,14 +84,14 @@ export default function ResetpasswordPage() {
                 onClick={() => finishResetMutation.mutate()}
                 aria-label="완료 버튼, 재설정 완료 화면으로 이동합니다."
               >
-                <span className="font-dpixel text-lg text-white">완료</span>
+                <span className={`${textStyle} text-white`}>완료</span>
               </Button>
               <Button
                 onClick={() => router.push('/')}
                 className="bg-blue-500 w-full hover:bg-opacity-70 hover:cursor-pointer"
                 aria-label="취소 버튼, 초기 화면으로 돌아갑니다."
               >
-                <span className="font-dpixel text-lg text-white">취소</span>
+                <span className={`${textStyle} text-white`}>취소</span>
               </Button>
             </form>
           </Card>

--- a/app/resetpassword/page.tsx
+++ b/app/resetpassword/page.tsx
@@ -6,6 +6,8 @@ import { useRouter } from 'next/navigation';
 import { createBrowserSupabaseClient } from 'utils/supabase/client';
 import { Card, Button } from '@mui/material';
 import Image from 'next/image';
+import Head from 'next/head';
+import AuthBackgroundCards from 'components/auth/auth-background-cards';
 
 export default function ResetpasswordPage() {
   const [newPassword, setNewPassword] = useState('');
@@ -34,68 +36,65 @@ export default function ResetpasswordPage() {
   });
 
   return (
-    <main className="area h-screen w-screen flex justify-center items-center">
-      <ul className="circles z-0">
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-      </ul>
-      <div className="flex flex-col items-center gap-4">
-        <Image
-          alt="텍스트 로고"
-          src="https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters/logo_text.webp"
-          width={180}
-          height={180}
-          className="w-auto h-auto"
-        />
-        <Card className="z-10 p-5 rounded-xl bg-white shadow-mainShadow">
-          <form className="w-80 max-w-screen-lg sm:w-96 flex flex-col gap-4">
-            <p className="text-center text-3xl font-bold font-dpixel">
-              비밀번호 재설정
-            </p>
-            <div className="flex gap-4 justify-between items-center">
-              <span className="font-dpixel text-lg">새 비밀번호</span>
-              <input
-                type="password"
-                value={newPassword}
-                placeholder="******"
-                className="border-gray-400"
-                onChange={(e) => setNewPassword(e.target.value)}
-              />
-            </div>
-            <div className="flex gap-4 justify-between items-center">
-              <span className="font-dpixel text-lg">비밀번호 확인</span>
-              <input
-                type="password"
-                value={newPasswordConfirm}
-                placeholder="******"
-                className="border-gray-400"
-                onChange={(e) => setNewPasswordConfirm(e.target.value)}
-              />
-            </div>
-            <Button
-              className="bg-main w-full hover:bg-opacity-70 hover:cursor-pointer"
-              disabled={newPassword !== newPasswordConfirm}
-              onClick={() => finishResetMutation.mutate()}
-            >
-              <span className="font-dpixel text-lg text-white">완료</span>
-            </Button>
-            <Button
-              onClick={() => router.push('/')}
-              className="bg-blue-500 w-full hover:bg-opacity-70 hover:cursor-pointer"
-            >
-              <span className="font-dpixel text-lg text-white">취소</span>
-            </Button>
-          </form>
-        </Card>
-      </div>
-    </main>
+    <>
+      <Head>
+        <title>비밀번호 재설정 | Cafe Masters</title>
+        <meta name="description" content={`새로운 비밀번호를 설정하세요.`} />
+      </Head>
+      <main className="area h-screen w-screen flex justify-center items-center">
+        <AuthBackgroundCards />
+        <div className="flex flex-col items-center gap-4">
+          <Image
+            alt="텍스트 로고 이미지"
+            src="https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters/logo_text.webp"
+            width={180}
+            height={180}
+            className="w-auto h-auto"
+          />
+          <Card className="z-10 p-5 rounded-xl bg-white shadow-mainShadow">
+            <form className="w-80 max-w-screen-lg sm:w-96 flex flex-col gap-4">
+              <p className="text-center text-3xl font-bold font-dpixel">
+                비밀번호 재설정
+              </p>
+              <div className="flex gap-4 justify-between items-center">
+                <span className="font-dpixel text-lg">새 비밀번호</span>
+                <input
+                  type="password"
+                  value={newPassword}
+                  placeholder="******"
+                  className="border-gray-400"
+                  onChange={(e) => setNewPassword(e.target.value)}
+                />
+              </div>
+              <div className="flex gap-4 justify-between items-center">
+                <span className="font-dpixel text-lg">비밀번호 확인</span>
+                <input
+                  type="password"
+                  value={newPasswordConfirm}
+                  placeholder="******"
+                  className="border-gray-400"
+                  onChange={(e) => setNewPasswordConfirm(e.target.value)}
+                />
+              </div>
+              <Button
+                className="bg-main w-full hover:bg-opacity-70 hover:cursor-pointer"
+                disabled={newPassword !== newPasswordConfirm}
+                onClick={() => finishResetMutation.mutate()}
+                aria-label="완료 버튼, 재설정 완료 화면으로 이동합니다."
+              >
+                <span className="font-dpixel text-lg text-white">완료</span>
+              </Button>
+              <Button
+                onClick={() => router.push('/')}
+                className="bg-blue-500 w-full hover:bg-opacity-70 hover:cursor-pointer"
+                aria-label="취소 버튼, 초기 화면으로 돌아갑니다."
+              >
+                <span className="font-dpixel text-lg text-white">취소</span>
+              </Button>
+            </form>
+          </Card>
+        </div>
+      </main>
+    </>
   );
 }

--- a/app/resetpassword/page.tsx
+++ b/app/resetpassword/page.tsx
@@ -26,9 +26,10 @@ export default function ResetpasswordPage() {
       console.error(error);
       alert('기존 비밀번호와 다른 비밀번호를 입력해주세요.');
     },
-    onSuccess: () => {
+    onSuccess: async () => {
+      await supabase.auth.signOut();
       alert('비밀번호를 재설정했습니다!');
-      router.push('/');
+      router.push('/resetpassword/complete');
     },
   });
 

--- a/components/auth/auth-background-cards.tsx
+++ b/components/auth/auth-background-cards.tsx
@@ -1,0 +1,16 @@
+export default function AuthBackgroundCards() {
+  return (
+    <ul className="circles z-0">
+      <li></li>
+      <li></li>
+      <li></li>
+      <li></li>
+      <li></li>
+      <li></li>
+      <li></li>
+      <li></li>
+      <li></li>
+      <li></li>
+    </ul>
+  );
+}

--- a/components/auth/index.tsx
+++ b/components/auth/index.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Signup from './signup';
 import Signin from './signin';
 import Image from 'next/image';
+import AuthBackgroundCards from './auth-background-cards';
 
 export default function Auth() {
   const [view, setView] = useState('SIGNIN');
@@ -16,18 +17,7 @@ export default function Auth() {
 
   return (
     <main className="area h-screen w-screen flex justify-center items-center">
-      <ul className="circles z-0">
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-        <li></li>
-      </ul>
+      <AuthBackgroundCards />
       <div className="flex flex-col items-center gap-4">
         <Image
           alt="텍스트 로고"

--- a/components/auth/index.tsx
+++ b/components/auth/index.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import Signup from './signup';
-import SignIn from './signin';
+import Signin from './signin';
 import Image from 'next/image';
 
 export default function Auth() {
@@ -39,7 +39,7 @@ export default function Auth() {
         {view === 'SIGNUP' ? (
           <Signup setView={setView} checkEmailVaild={checkEmailVaild} />
         ) : (
-          <SignIn setView={setView} checkEmailVaild={checkEmailVaild} />
+          <Signin setView={setView} checkEmailVaild={checkEmailVaild} />
         )}
       </div>
     </main>

--- a/components/auth/otp-form.tsx
+++ b/components/auth/otp-form.tsx
@@ -1,0 +1,19 @@
+interface OtpFormProps {
+  otp: string;
+  setOtp: (state: any) => void;
+}
+
+export default function OtpForm({ otp, setOtp }: OtpFormProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      <span className="text-xl font-dpixel">인증 코드</span>
+      <input
+        value={otp}
+        onChange={(e) => setOtp(e.target.value)}
+        placeholder="6자리 인증 코드를 입력하세요"
+        type="text"
+        className="p-2"
+      />
+    </div>
+  );
+}

--- a/components/auth/resetpassword-form.tsx
+++ b/components/auth/resetpassword-form.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@mui/material';
+
+interface ResetpasswordFormProps {
+  email: string;
+  setEmail: (state: any) => void;
+  resetRequested: string;
+  resetFn: () => void;
+  cancelFn: () => void;
+}
+
+export default function ResetpasswordForm({
+  email,
+  setEmail,
+  resetRequested,
+  resetFn,
+  cancelFn,
+}: ResetpasswordFormProps) {
+  return (
+    <div className="w-80 max-w-screen-lg sm:w-96 flex flex-col gap-4">
+      <p className="text-center text-3xl font-bold font-dpixel">
+        비밀번호 재설정
+      </p>
+      <div className="flex gap-4 justify-between items-center">
+        <span className="w-20 font-dpixel text-lg">이메일</span>
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value.trim())}
+          placeholder="아이디@주소"
+          className="border-gray-400 w-full"
+        />
+      </div>
+      <span className="text-success font-bold">{resetRequested}</span>
+      <Button
+        aria-label="비밀번호 재설정 링크 메일 요청 버튼"
+        className="bg-main w-full hover:bg-opacity-70 hover:cursor-pointer"
+        onClick={resetFn}
+      >
+        <span className="font-dpixel text-lg text-white">재설정하기</span>
+      </Button>
+      <Button
+        aria-label="비밀번호 재설정 취소 버튼"
+        onClick={cancelFn}
+        className="bg-blue-500 w-full hover:bg-opacity-70 hover:cursor-pointer"
+      >
+        <span className="font-dpixel text-lg text-white">취소</span>
+      </Button>
+    </div>
+  );
+}

--- a/components/auth/signin.tsx
+++ b/components/auth/signin.tsx
@@ -7,6 +7,7 @@ import { signInWithKakao } from 'utils/supabase/signinKakao';
 import { createBrowserSupabaseClient } from 'utils/supabase/client';
 import { Card, Button } from '@mui/material';
 import UserForm from './user-form';
+import ResetpasswordForm from './resetpassword-form';
 
 export default function Signin({ setView, checkEmailVaild }: any) {
   const [email, setEmail] = useState('');
@@ -70,33 +71,13 @@ export default function Signin({ setView, checkEmailVaild }: any) {
   return (
     <Card className="p-5 rounded-xl bg-white shadow-mainShadow z-10">
       {resetRequired ? (
-        <div className="w-80 max-w-screen-lg sm:w-96 flex flex-col gap-4">
-          <p className="text-center text-3xl font-bold font-dpixel">
-            비밀번호 재설정
-          </p>
-          <div className="flex gap-4 justify-between items-center">
-            <span className="w-20 font-dpixel text-lg">이메일</span>
-            <input
-              value={email.trim()}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="아이디@주소"
-              className="border-gray-400 w-full"
-            />
-          </div>
-          <span className="text-success">{resetRequested}</span>
-          <Button
-            className="bg-main w-full hover:bg-opacity-70 hover:cursor-pointer"
-            onClick={() => resetPasswordMutation.mutate()}
-          >
-            <span className="font-dpixel text-lg text-white">재설정하기</span>
-          </Button>
-          <Button
-            onClick={() => setResetRequired(false)}
-            className="bg-blue-500 w-full hover:bg-opacity-70 hover:cursor-pointer"
-          >
-            <span className="font-dpixel text-lg text-white">취소</span>
-          </Button>
-        </div>
+        <ResetpasswordForm
+          email={email}
+          setEmail={setEmail}
+          resetRequested={resetRequested}
+          resetFn={() => resetPasswordMutation.mutate()}
+          cancelFn={() => setResetRequired(false)}
+        />
       ) : (
         <div>
           <p className="text-center text-3xl font-bold font-dpixel">로그인</p>
@@ -109,23 +90,31 @@ export default function Signin({ setView, checkEmailVaild }: any) {
             />
             <span className="text-red-500">{emailError}</span>
             <Button
-              className="bg-main w-full font-dpixel text-white hover:bg-opacity-70 hover:cursor-pointer"
+              aria-label="로그인 버튼"
+              className="bg-main w-full hover:bg-opacity-70 hover:cursor-pointer"
               onClick={handleSignIn}
               disabled={signinMutation.isPending || password.length < 6}
+              sx={{
+                '&.Mui-disabled': {
+                  backgroundColor: '#ccc',
+                },
+              }}
             >
-              접속하기
+              <span className="font-dpixel text-white">접속하기</span>
             </Button>
             <Button
-              className="bg-blue-600 w-full font-dpixel text-white hover:bg-opacity-70 hover:cursor-pointer"
+              aria-label="비밀번호 재설정 폼 열기 버튼"
+              className="bg-blue-600 w-full hover:bg-opacity-70 hover:cursor-pointer"
               onClick={() => setResetRequired(true)}
             >
-              비밀번호 재설정
+              <span className="font-dpixel text-white">비밀번호 재설정</span>
             </Button>
             <Button
-              className="bg-yellow-500 w-full text-white font-dpixel hover:bg-opacity-70 hover:cursor-pointer"
+              aria-label="카카오 로그인 버튼"
+              className="bg-yellow-500 w-full hover:bg-opacity-70 hover:cursor-pointer"
               onClick={() => signInWithKakao()}
             >
-              카카오 로그인
+              <span className="font-dpixel text-white">카카오 로그인</span>
             </Button>
             <span
               color="gray"
@@ -133,6 +122,7 @@ export default function Signin({ setView, checkEmailVaild }: any) {
             >
               계정이 없으신가요?{' '}
               <Button
+                aria-label="회원가입 폼 열기 버튼"
                 onClick={() => setView('SIGNUP')}
                 className="hover:cursor-pointer hover:bg-gray-100"
               >

--- a/components/auth/signin.tsx
+++ b/components/auth/signin.tsx
@@ -6,6 +6,12 @@ import { useUserStore } from 'utils/store';
 import { signInWithKakao } from 'utils/supabase/signinKakao';
 import { createBrowserSupabaseClient } from 'utils/supabase/client';
 import { Card, Button } from '@mui/material';
+import {
+  getAuthFormCardStyle,
+  getAuthFormMentionStyle,
+  getAuthFormTitleStyle,
+  getKakaoButtonStyle,
+} from 'utils/styles';
 import UserForm from './user-form';
 import ResetpasswordForm from './resetpassword-form';
 
@@ -50,7 +56,10 @@ export default function Signin({ setView, checkEmailVaild }: any) {
     onSuccess: () => {
       setResetRequested('이메일의 보관함을 확인해주세요.');
     },
-    onError: (error: Error) => console.error(error),
+    onError: (error: Error) => {
+      console.error(error);
+      alert('재요청은 60초가 지나야 가능합니다.');
+    },
   });
 
   const checkEmail = () => {
@@ -69,7 +78,7 @@ export default function Signin({ setView, checkEmailVaild }: any) {
   };
 
   return (
-    <Card className="p-5 rounded-xl bg-white shadow-mainShadow z-10">
+    <Card className={getAuthFormCardStyle()}>
       {resetRequired ? (
         <ResetpasswordForm
           email={email}
@@ -80,7 +89,7 @@ export default function Signin({ setView, checkEmailVaild }: any) {
         />
       ) : (
         <div>
-          <p className="text-center text-3xl font-bold font-dpixel">로그인</p>
+          <p className={getAuthFormTitleStyle()}>로그인</p>
           <form className="w-80 max-w-screen-lg sm:w-96 flex flex-col gap-4">
             <UserForm
               email={email}
@@ -111,15 +120,12 @@ export default function Signin({ setView, checkEmailVaild }: any) {
             </Button>
             <Button
               aria-label="카카오 로그인 버튼"
-              className="bg-yellow-500 w-full hover:bg-opacity-70 hover:cursor-pointer"
+              className={getKakaoButtonStyle()}
               onClick={() => signInWithKakao()}
             >
               <span className="font-dpixel text-white">카카오 로그인</span>
             </Button>
-            <span
-              color="gray"
-              className="flex items-center justify-center gap-4 text-center font-dpixel"
-            >
+            <span color="gray" className={getAuthFormMentionStyle()}>
               계정이 없으신가요?{' '}
               <Button
                 aria-label="회원가입 폼 열기 버튼"

--- a/components/auth/signin.tsx
+++ b/components/auth/signin.tsx
@@ -8,7 +8,7 @@ import { createBrowserSupabaseClient } from 'utils/supabase/client';
 import { Card, Button } from '@mui/material';
 import UserForm from './user-form';
 
-export default function SignIn({ setView, checkEmailVaild }: any) {
+export default function Signin({ setView, checkEmailVaild }: any) {
   const [email, setEmail] = useState('');
   const [emailError, setEmailError] = useState<string | null>(null);
   const [password, setPassword] = useState('');
@@ -16,6 +16,7 @@ export default function SignIn({ setView, checkEmailVaild }: any) {
   const [resetRequested, setResetRequested] = useState('');
   const supabase = createBrowserSupabaseClient();
   const setUserId = useUserStore((state: any) => state.setUserId);
+  const setUserEmail = useUserStore((state: any) => state.setUserEmail);
 
   const signinMutation = useMutation({
     mutationFn: async () => {
@@ -25,8 +26,12 @@ export default function SignIn({ setView, checkEmailVaild }: any) {
       });
 
       if (error) throw new Error(error.message);
-      if (data) setUserId(data?.user?.id);
+      if (data) {
+        setUserId(data?.user?.id);
+        setUserEmail(data?.user?.email?.split('@')?.[0]);
+      }
     },
+
     onError: (error: Error) => {
       if (error.message === 'Invalid login credentials')
         alert('이메일 또는 비밀번호를 잘못 입력했습니다.');
@@ -37,7 +42,7 @@ export default function SignIn({ setView, checkEmailVaild }: any) {
   const resetPasswordMutation = useMutation({
     mutationFn: async () => {
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: 'http://localhost:3000/auth/resetpassword',
+        redirectTo: `${process.env.NEXT_PUBLIC_API_REQUEST_URI}/resetpassword`,
       });
       if (error) throw new Error(error.message);
     },
@@ -72,7 +77,7 @@ export default function SignIn({ setView, checkEmailVaild }: any) {
           <div className="flex gap-4 justify-between items-center">
             <span className="w-20 font-dpixel text-lg">이메일</span>
             <input
-              value={email}
+              value={email.trim()}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="아이디@주소"
               className="border-gray-400 w-full"
@@ -129,7 +134,7 @@ export default function SignIn({ setView, checkEmailVaild }: any) {
               계정이 없으신가요?{' '}
               <Button
                 onClick={() => setView('SIGNUP')}
-                className="hover:cursor-pointer"
+                className="hover:cursor-pointer hover:bg-gray-100"
               >
                 <span className="font-bold font-dpixel text-main">
                   회원가입

--- a/components/auth/signup.tsx
+++ b/components/auth/signup.tsx
@@ -6,11 +6,12 @@ import { Card, Button } from '@mui/material';
 import { createBrowserSupabaseClient } from 'utils/supabase/client';
 import { signInWithKakao } from 'utils/supabase/signinKakao';
 import UserForm from './user-form';
+import OtpForm from './otp-form';
 
 export default function Signup({ setView, checkEmailVaild }: any) {
   const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
   const [emailError, setEmailError] = useState<string | null>(null);
+  const [password, setPassword] = useState('');
   const [confirmationRequired, setConfirmationRequired] = useState(false);
   const [otp, setOtp] = useState('');
 
@@ -68,16 +69,7 @@ export default function Signup({ setView, checkEmailVaild }: any) {
       <p className="text-center text-3xl font-bold font-dpixel">회원가입</p>
       <form className="w-80 max-w-screen-lg sm:w-96 flex flex-col gap-4">
         {confirmationRequired ? (
-          <div className="flex flex-col gap-6">
-            <span className="text-xl font-dpixel">인증 코드</span>
-            <input
-              value={otp}
-              onChange={(e) => setOtp(e.target.value)}
-              placeholder="6자리 인증 코드를 입력하세요"
-              type="text"
-              className="p-2"
-            />
-          </div>
+          <OtpForm otp={otp} setOtp={setOtp} />
         ) : (
           <UserForm
             email={email}
@@ -89,7 +81,8 @@ export default function Signup({ setView, checkEmailVaild }: any) {
         <span className="text-red-500">{emailError}</span>
         <span>*비밀번호는 최소 6자 이상 입력해야 합니다.</span>
         <Button
-          className="w-full bg-main font-dpixel text-white hover:bg-opacity-70 hover:cursor-pointer"
+          aria-label="인증 코드 확인 버튼 | 회원가입 요청 버튼"
+          className="w-full bg-main hover:bg-opacity-70 hover:cursor-pointer"
           onClick={() => {
             if (confirmationRequired) verifyOtpMutation.mutate();
             else handleSignUp();
@@ -99,14 +92,24 @@ export default function Signup({ setView, checkEmailVaild }: any) {
               ? verifyOtpMutation.isPending || otp.length < 6
               : signupMutation.isPending || password.length < 6
           }
+          sx={{
+            '&.Mui-disabled': {
+              backgroundColor: '#ccc',
+            },
+          }}
         >
-          {confirmationRequired ? '인증 코드 확인' : '가입하기'}
+          <span className="font-dpixel text-lg text-white">
+            {confirmationRequired ? '인증 코드 확인' : '가입하기'}
+          </span>
         </Button>
         <Button
-          className="w-full bg-yellow-500 font-dpixel text-white hover:bg-opacity-70 hover:cursor-pointer"
+          aria-label="카카오 로그인 버튼"
+          className="w-full bg-yellow-500 hover:bg-opacity-70 hover:cursor-pointer"
           onClick={() => signInWithKakao()}
         >
-          카카오로 회원가입
+          <span className="font-dpixel text-lg text-white">
+            카카오로 회원가입
+          </span>
         </Button>
         <span
           color="gray"
@@ -114,6 +117,7 @@ export default function Signup({ setView, checkEmailVaild }: any) {
         >
           이미 계정이 있으신가요?{' '}
           <Button
+            aria-label="로그인 폼 열기 버튼"
             onClick={() => setView('SIGNIN')}
             className="hover:cursor-pointer hover:bg-gray-100"
           >

--- a/components/auth/signup.tsx
+++ b/components/auth/signup.tsx
@@ -5,6 +5,12 @@ import { useMutation } from '@tanstack/react-query';
 import { Card, Button } from '@mui/material';
 import { createBrowserSupabaseClient } from 'utils/supabase/client';
 import { signInWithKakao } from 'utils/supabase/signinKakao';
+import {
+  getAuthFormCardStyle,
+  getAuthFormMentionStyle,
+  getAuthFormTitleStyle,
+  getKakaoButtonStyle,
+} from 'utils/styles';
 import UserForm from './user-form';
 import OtpForm from './otp-form';
 
@@ -65,8 +71,8 @@ export default function Signup({ setView, checkEmailVaild }: any) {
   };
 
   return (
-    <Card className="p-5 rounded-xl bg-white shadow-mainShadow z-10">
-      <p className="text-center text-3xl font-bold font-dpixel">회원가입</p>
+    <Card className={getAuthFormCardStyle()}>
+      <p className={getAuthFormTitleStyle()}>회원가입</p>
       <form className="w-80 max-w-screen-lg sm:w-96 flex flex-col gap-4">
         {confirmationRequired ? (
           <OtpForm otp={otp} setOtp={setOtp} />
@@ -104,17 +110,14 @@ export default function Signup({ setView, checkEmailVaild }: any) {
         </Button>
         <Button
           aria-label="카카오 로그인 버튼"
-          className="w-full bg-yellow-500 hover:bg-opacity-70 hover:cursor-pointer"
+          className={getKakaoButtonStyle()}
           onClick={() => signInWithKakao()}
         >
           <span className="font-dpixel text-lg text-white">
             카카오로 회원가입
           </span>
         </Button>
-        <span
-          color="gray"
-          className="flex items-center justify-center gap-4 text-center font-dpixel hover:cursor-pointer"
-        >
+        <span color="gray" className={getAuthFormMentionStyle()}>
           이미 계정이 있으신가요?{' '}
           <Button
             aria-label="로그인 폼 열기 버튼"

--- a/components/auth/signup.tsx
+++ b/components/auth/signup.tsx
@@ -22,13 +22,14 @@ export default function Signup({ setView, checkEmailVaild }: any) {
         email,
         password,
         options: {
-          emailRedirectTo: 'http://localhost:3000/signup/confirm',
+          emailRedirectTo: `${process.env.NEXT_PUBLIC_API_REQUEST_URI}/signup/confirm`,
         },
       });
 
       if (error) throw new Error(error.message);
       if (data) setConfirmationRequired(true);
     },
+
     onError: (error: Error) => console.error(error),
   });
 
@@ -43,6 +44,7 @@ export default function Signup({ setView, checkEmailVaild }: any) {
       if (error) throw new Error(error.message);
       if (data) setConfirmationRequired(true);
     },
+
     onError: (error: Error) => console.error(error),
   });
 
@@ -113,7 +115,7 @@ export default function Signup({ setView, checkEmailVaild }: any) {
           이미 계정이 있으신가요?{' '}
           <Button
             onClick={() => setView('SIGNIN')}
-            className="hover:cursor-pointer hover:bg-gray-300 hover:opcity-70"
+            className="hover:cursor-pointer hover:bg-gray-100"
           >
             <span className="font-bold font-dpixel text-main">로그인 하기</span>
           </Button>

--- a/components/layouts/main-layout.tsx
+++ b/components/layouts/main-layout.tsx
@@ -1,15 +1,16 @@
+'use client';
+
 import { ReactNode } from 'react';
 import Sidebar from 'components/layouts/sidebar/sidebar';
 
 interface MainLayout {
   children: ReactNode;
-  session: any;
 }
 
-export default function MainLayout({ children, session }: MainLayout) {
+export default function MainLayout({ children }: MainLayout) {
   return (
     <main className="flex">
-      <Sidebar session={session} />
+      <Sidebar />
       {children}
     </main>
   );

--- a/components/layouts/map.tsx
+++ b/components/layouts/map.tsx
@@ -22,8 +22,6 @@ export default function KakaoMap() {
   const thisX = useMapStore((state: any) => state.thisX);
   const thisY = useMapStore((state: any) => state.thisY);
 
-  if (pathname.startsWith('/auth')) return null;
-
   useEffect(() => {
     const script = document.createElement('script');
     script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_KEY}&libraries=services&autoload=false`;
@@ -251,6 +249,8 @@ export default function KakaoMap() {
         ) {
           displayDetailCenter(thisX, thisY);
         }
+
+        if (pathname.startsWith('/resetpassword')) return null;
       });
     };
 
@@ -258,6 +258,8 @@ export default function KakaoMap() {
       script.remove();
     };
   }, [keyword, pathname]);
+
+  if (pathname.startsWith('/resetpassword')) return null;
 
   return <div id="map" className={getMapStyle()} />;
 }

--- a/components/layouts/sidebar/collected-card.tsx
+++ b/components/layouts/sidebar/collected-card.tsx
@@ -9,6 +9,7 @@ import {
   getUniqueCardEffectStyle,
 } from 'utils/styles';
 import { CollectedCardProps } from 'types/types';
+import Image from 'next/image';
 
 export default function CollectedCard({
   name,
@@ -52,7 +53,13 @@ export default function CollectedCard({
             ))}
         </div>
         <div className="flex justify-center rounded-xl">
-          <img src={photoUrl} alt="cafe_img" className="h-20 rounded-lg" />
+          <Image
+            src={photoUrl}
+            alt="카페 썸네일 이미지"
+            width={100}
+            height={50}
+            className="w-auto h-auto"
+          />
         </div>
         <div className="flex flex-col shadow-gray-500 shadow-md px-2">
           <span className="text-sm">{address}</span>

--- a/components/layouts/sidebar/footer/footer.tsx
+++ b/components/layouts/sidebar/footer/footer.tsx
@@ -3,10 +3,10 @@
 import LogoutButton from './logout-button';
 import Profile from './profile';
 
-export default function Footer({ session }: any) {
+export default function Footer() {
   return (
     <div className={`flex flex-col gap-10 items-center`}>
-      <Profile session={session} />
+      <Profile />
       <LogoutButton />
     </div>
   );

--- a/components/layouts/sidebar/footer/logout-button.tsx
+++ b/components/layouts/sidebar/footer/logout-button.tsx
@@ -21,7 +21,7 @@ export default function LogoutButton() {
       className={getLogoutButtonStyle()}
       onClick={handleLogout}
     >
-      <span className="text-white text-2xl sm:text-lg font-dpixel">
+      <span className="text-white font-dpixel text-2xl sm:text-lg">
         로그아웃
       </span>
     </Button>

--- a/components/layouts/sidebar/footer/logout-button.tsx
+++ b/components/layouts/sidebar/footer/logout-button.tsx
@@ -16,7 +16,11 @@ export default function LogoutButton() {
   };
 
   return (
-    <Button className={getLogoutButtonStyle()} onClick={handleLogout}>
+    <Button
+      aria-label="로그아웃 버튼"
+      className={getLogoutButtonStyle()}
+      onClick={handleLogout}
+    >
       <span className="text-white text-2xl sm:text-lg font-dpixel">
         로그아웃
       </span>

--- a/components/layouts/sidebar/footer/page-converter.tsx
+++ b/components/layouts/sidebar/footer/page-converter.tsx
@@ -19,6 +19,7 @@ export default function PageConverter({
     <div className={getPageConverterStyle(isDarkTheme)}>
       <div className="flex justify-between items-center">
         <button
+          aria-label="이전 페이지 번호"
           onClick={handlePreviousPage}
           disabled={currentPage === 1}
           className={`px-4 py-2 text-3xl ${
@@ -31,6 +32,7 @@ export default function PageConverter({
           {currentPage} / {totalPages}
         </span>
         <button
+          aria-label="다음 페이지 번호"
           onClick={handleNextPage}
           disabled={currentPage === totalPages}
           className={`px-4 py-2 text-3xl ${

--- a/components/layouts/sidebar/footer/profile.tsx
+++ b/components/layouts/sidebar/footer/profile.tsx
@@ -30,7 +30,7 @@ export default function Profile() {
         src={
           'https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters/profile_image.webp'
         }
-        alt="프로필 이미지"
+        alt="유저 프로필 이미지"
         width={60}
         height={60}
         className="relative inline-block object-cover object-center rounded-lg w-auto h-auto"

--- a/components/layouts/sidebar/footer/profile.tsx
+++ b/components/layouts/sidebar/footer/profile.tsx
@@ -36,7 +36,7 @@ export default function Profile() {
         className="relative inline-block object-cover object-center rounded-lg w-auto h-auto"
       />
       <div className="flex gap-4 items-center">
-        <h6 className="font-bold text-3xl sm:text-2xl font-dpixel">
+        <h6 className="font-bold font-dpixel text-3xl sm:text-2xl">
           {userEmail}
         </h6>
         <TierBadge tier={userTier} />

--- a/components/layouts/sidebar/footer/profile.tsx
+++ b/components/layouts/sidebar/footer/profile.tsx
@@ -5,10 +5,11 @@ import { useMapStore, useUserStore } from 'utils/store';
 import TierBadge from './tier-badge';
 import Image from 'next/image';
 
-export default function Profile({ session }: any) {
+export default function Profile() {
   const collectedCafeCount = useMapStore(
     (state: any) => state.collectedCafeCount
   );
+  const userEmail = useUserStore((state: any) => state.userEmail);
   const userTier = useUserStore((state: any) => state.userTier);
   const setUserTier = useUserStore((state: any) => state.setUserTier);
 
@@ -36,7 +37,7 @@ export default function Profile({ session }: any) {
       />
       <div className="flex gap-4 items-center">
         <h6 className="font-bold text-3xl sm:text-2xl font-dpixel">
-          {session?.user?.email?.split('@')?.[0]}
+          {userEmail}
         </h6>
         <TierBadge tier={userTier} />
       </div>

--- a/components/layouts/sidebar/footer/tier-badge.tsx
+++ b/components/layouts/sidebar/footer/tier-badge.tsx
@@ -23,9 +23,9 @@ export default function TierBadge({ tier }: TierBadgeProps) {
   };
 
   return (
-    <div>
+    <div className="hover:opacity-70 transform duration-500 ease-in">
       <Tooltip title="티어 정보" placement="right-end">
-        <div className="relative flex items-center">
+        <div className="relative flex items-center justify-center">
           {tier === 'MASTER' && (
             <div className={getMasterEffectStyle('w-[100%]')}></div>
           )}

--- a/components/layouts/sidebar/footer/tier-info-modal.tsx
+++ b/components/layouts/sidebar/footer/tier-info-modal.tsx
@@ -42,7 +42,7 @@ export default function TierInfoModal({
 }: TierInfoModalProps) {
   const isDarkTheme = useCheckStore((state: any) => state.isDarkTheme);
 
-  const tierDescStyle = 'sm:text-md text-xs font-dpixel';
+  const tierDescStyle = 'sm:text-lg text-xs font-dpixel';
 
   return (
     <div>
@@ -98,7 +98,7 @@ export default function TierInfoModal({
             어엿한 카페 고수입니다 뿌듯하셔도 좋아요!!
           </span>
           <div className="flex items-center gap-3 relative">
-            <div className={getMasterEffectStyle('w-[16%]')}></div>
+            <div className={getMasterEffectStyle('w-[15%]')}></div>
             <div className={getMasterTierStyle(getBadgeCommon)}>
               <span className="text-sm font-dpixel">MASTER</span>
             </div>

--- a/components/layouts/sidebar/footer/tier-info-modal.tsx
+++ b/components/layouts/sidebar/footer/tier-info-modal.tsx
@@ -42,7 +42,7 @@ export default function TierInfoModal({
 }: TierInfoModalProps) {
   const isDarkTheme = useCheckStore((state: any) => state.isDarkTheme);
 
-  const tierDescStyle = 'sm:text-lg text-xs font-dpixel';
+  const tierDescStyle = 'font-dpixel lg:text-lg text-xs';
 
   return (
     <div>
@@ -55,10 +55,10 @@ export default function TierInfoModal({
       >
         <Box
           className={`${isDarkTheme ? 'bg-darkbg text-white border-darkaccent border-4' : 'bg-white border-mainShadow border-4'}
-          absolute top-1/2 left-1/2 -translate-x-[50%] -translate-y-[50%] sm:w-[30%] w-[80%] h-[70%] shadow-md p-4 flex flex-col gap-4 justify-center`}
+          absolute top-1/2 left-1/2 -translate-x-[50%] -translate-y-[50%] sm:w-[30%] md:w-[50%] w-[80%] h-[70%] shadow-md p-4 flex flex-col gap-4 justify-center`}
         >
           <div className="flex flex-col">
-            <span className="text-2xl sm:text-3xl font-dpixel">
+            <span className="font-dpixel text-2xl md:text-3xl">
               TIER INFORMATION
             </span>
             <span className={tierDescStyle}>
@@ -97,12 +97,12 @@ export default function TierInfoModal({
           <span className={tierDescStyle}>
             어엿한 카페 고수입니다 뿌듯하셔도 좋아요!!
           </span>
-          <div className="flex items-center gap-3 relative">
-            <div className={getMasterEffectStyle('w-[15%]')}></div>
+          <div className="relative flex items-center gap-3">
+            <div className={getMasterEffectStyle('w-[11%]')}></div>
             <div className={getMasterTierStyle(getBadgeCommon)}>
               <span className="text-sm font-dpixel">MASTER</span>
             </div>
-            <span className="relative z-10 text-xl font-dpixel">50</span>
+            <span className="z-10 relative text-xl font-dpixel">50</span>
           </div>
           <span className={tierDescStyle}>
             마스터여, 당신은 월드의 주인입니다

--- a/components/layouts/sidebar/header/header.tsx
+++ b/components/layouts/sidebar/header/header.tsx
@@ -22,8 +22,9 @@ export default function Header() {
           width={60}
           className="w-auto h-auto"
         />
-        <Tooltip title="홈으로" placement="right-end">
+        <Tooltip title="홈페이지" placement="right-end">
           <button
+            aria-label="홈페이지 이동 버튼"
             className="cursor-pointer flex items-center hover:opacity-70 transition ease duration-300"
             onClick={() => router.push('/')}
           >

--- a/components/layouts/sidebar/header/header.tsx
+++ b/components/layouts/sidebar/header/header.tsx
@@ -25,7 +25,7 @@ export default function Header() {
         <Tooltip title="홈페이지" placement="right-end">
           <button
             aria-label="홈페이지 이동 버튼"
-            className="cursor-pointer flex items-center hover:opacity-70 transition ease duration-300"
+            className="flex items-center hover:opacity-70 hover:cursor-pointer transition ease duration-300"
             onClick={() => router.push('/')}
           >
             <Image

--- a/components/layouts/sidebar/header/light-dark-toggle.tsx
+++ b/components/layouts/sidebar/header/light-dark-toggle.tsx
@@ -10,7 +10,7 @@ export default function LightDarkToggle() {
     <button
       aria-label="라이트/다크 테마 토글 버튼"
       onClick={handleToggle}
-      className="w-14 h-14"
+      className="w-14 h-14 hover:opacity-70 transform duration-300 ease-out"
     >
       {isDarkTheme ? (
         <i className="fa-regular fa-sun text-white text-3xl"></i>

--- a/components/layouts/sidebar/header/light-dark-toggle.tsx
+++ b/components/layouts/sidebar/header/light-dark-toggle.tsx
@@ -7,7 +7,11 @@ export default function LightDarkToggle() {
   const handleToggle = () => setIsDarkTheme();
 
   return (
-    <button onClick={handleToggle} className="w-14 h-14">
+    <button
+      aria-label="라이트/다크 테마 토글 버튼"
+      onClick={handleToggle}
+      className="w-14 h-14"
+    >
       {isDarkTheme ? (
         <i className="fa-regular fa-sun text-white text-3xl"></i>
       ) : (

--- a/components/layouts/sidebar/header/search.tsx
+++ b/components/layouts/sidebar/header/search.tsx
@@ -46,6 +46,7 @@ export default function Search() {
             onKeyDown={handleKeyDown}
           />
           <button
+            aria-label="검색 버튼"
             className={getSearchButtonStyle()}
             type="button"
             onClick={handleSearch}

--- a/components/layouts/sidebar/normal-card.tsx
+++ b/components/layouts/sidebar/normal-card.tsx
@@ -15,7 +15,7 @@ export default function NormalCard({
   return (
     <Card onClick={onClick} className={getNormalCardStyle(isDarkTheme)}>
       <span
-        className={`px-2 py-1 shadow-md ${isDarkTheme ? 'shadow-mainShadow' : 'shadow-gray-700'}`}
+        className={`${isDarkTheme ? 'shadow-mainShadow' : 'shadow-gray-700'} px-2 py-1 shadow-md`}
       >
         {name}
       </span>
@@ -29,7 +29,7 @@ export default function NormalCard({
         />
       </div>
       <div
-        className={`flex flex-col px-2 shadow-md ${isDarkTheme ? 'shadow-mainShadow' : 'shadow-gray-700'}`}
+        className={`${isDarkTheme ? 'shadow-mainShadow' : 'shadow-gray-700'} flex flex-col px-2 shadow-md`}
       >
         <span className="text-sm">{address}</span>
         <span>{phoneNum}</span>

--- a/components/layouts/sidebar/normal-card.tsx
+++ b/components/layouts/sidebar/normal-card.tsx
@@ -22,9 +22,10 @@ export default function NormalCard({
       <div className="flex justify-center">
         <Image
           src="https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters/search_thumbnail.webp"
-          alt="cafe_img"
+          alt="카페 썸네일 이미지"
           width={100}
           height={50}
+          className="w-auto h-auto"
         />
       </div>
       <div

--- a/components/layouts/sidebar/sidebar-tab-list.tsx
+++ b/components/layouts/sidebar/sidebar-tab-list.tsx
@@ -27,13 +27,14 @@ function SidebarTab({ icon, title, path, isDarkTheme }: SidebarTabProps) {
 export default function SidebarTabList() {
   const isDarkTheme = useCheckStore((state: any) => state.isDarkTheme);
   const router = useRouter();
+  const iconStyle = 'fa-solid text-3xl sm:text-2xl';
 
   return (
     <List className="mt-2 flex flex-col gap-10 sm:gap-5 px-10 sm:px-4">
       <SidebarTab
         icon={
           <i
-            className={`fa-solid fa-bars text-3xl sm:text-2xl ${isDarkTheme ? 'text-white' : ''}`}
+            className={`${isDarkTheme ? 'text-white' : ''} ${iconStyle} fa-bars`}
           ></i>
         }
         title={'모든 카페 보기'}
@@ -43,7 +44,7 @@ export default function SidebarTabList() {
       <SidebarTab
         icon={
           <i
-            className={`fa-solid fa-file text-3xl sm:text-2xl ${isDarkTheme ? 'text-white' : 'text-main'}`}
+            className={`${isDarkTheme ? 'text-white' : 'text-main'} ${iconStyle} fa-file`}
           ></i>
         }
         title={'수집한 카드 보기'}
@@ -53,7 +54,7 @@ export default function SidebarTabList() {
       <SidebarTab
         icon={
           <i
-            className={`fa-solid fa-bookmark text-3xl sm:text-xl ${isDarkTheme ? 'text-white' : 'text-yellow-500'}`}
+            className={`${isDarkTheme ? 'text-white' : 'text-yellow-500'} ${iconStyle} fa-bookmark`}
           ></i>
         }
         title={'가고 싶은 카페 보기'}

--- a/components/layouts/sidebar/sidebar.tsx
+++ b/components/layouts/sidebar/sidebar.tsx
@@ -173,7 +173,7 @@ export default function Sidebar() {
 
           <div className="px-8 sm:px-4">
             {pathname.startsWith('/cafe/all') && (
-              <div className="flex flex-col gap-8 my-4">
+              <div className="flex flex-col gap-8 my-8">
                 {paginatedResults.map((cafe: any) => (
                   <NormalCard
                     key={cafe.id}
@@ -201,7 +201,7 @@ export default function Sidebar() {
                 )}
 
                 {collectedData?.pages?.map((page, i) => (
-                  <div key={`page-${i}`} className="flex flex-col gap-8 my-4">
+                  <div key={`page-${i}`} className="flex flex-col gap-8 my-8">
                     {page.data.map((cafe: any) => (
                       <CollectedCard
                         key={cafe.id}
@@ -228,7 +228,7 @@ export default function Sidebar() {
                 )}
 
                 {bookmarkedData?.pages?.map((page, i) => (
-                  <div key={`page-${i}`} className="flex flex-col gap-8 my-4">
+                  <div key={`page-${i}`} className="flex flex-col gap-8 my-8">
                     {page.data.map((cafe: any) => (
                       <NormalCard
                         key={cafe.id}

--- a/components/layouts/sidebar/sidebar.tsx
+++ b/components/layouts/sidebar/sidebar.tsx
@@ -16,7 +16,7 @@ import CollectedCard from './collected-card';
 import PageConverter from './footer/page-converter';
 import SidebarTabList from './sidebar-tab-list';
 
-export default function Sidebar({ session }: any) {
+export default function Sidebar() {
   const [currentPage, setCurrentPage] = useState(1);
   const { ref: collectedRef, inView: collectedInView } = useInView({
     threshold: 0.5,
@@ -159,7 +159,7 @@ export default function Sidebar({ session }: any) {
     }
   }, [bookmarkedInView, hasNextBookmarkedPage, fetchNextBookmarkedPage]);
 
-  if (pathname.startsWith('/auth')) return null;
+  if (pathname.startsWith('/resetpassword')) return null;
 
   return (
     <div className="relative flex items-center">
@@ -255,7 +255,7 @@ export default function Sidebar({ session }: any) {
             />
           )}
 
-          {pathname === '/' && <Footer session={session} />}
+          {pathname === '/' && <Footer />}
         </div>
       </Card>
 

--- a/components/layouts/sub-sidebar/collected-cafe-detail.tsx
+++ b/components/layouts/sub-sidebar/collected-cafe-detail.tsx
@@ -51,9 +51,15 @@ export default function CollectedCafeDetail({
           <Image
             src={collectedCafeDetail?.photoUrl}
             alt="카페 썸네일"
-            className="w-auto h-auto rounded-md"
+            className="rounded-md w-auto h-auto transform duration-300 ease-out hover:opacity-70 hover:cursor-pointer"
             width={160}
             height={30}
+            onClick={() =>
+              window.open(
+                `http://place.map.kakao.com/${collectedCafeDetail?.id}`,
+                '_blank'
+              )
+            }
           />
         </div>
 

--- a/components/layouts/sub-sidebar/collected-cafe-detail.tsx
+++ b/components/layouts/sub-sidebar/collected-cafe-detail.tsx
@@ -51,7 +51,7 @@ export default function CollectedCafeDetail({
           <Image
             src={collectedCafeDetail?.photoUrl}
             alt="카페 썸네일"
-            className="rounded-md w-auto h-auto transform duration-300 ease-out hover:opacity-70 hover:cursor-pointer"
+            className="rounded-md w-auto h-auto transform duration-300 ease-out hover:opacity-30 hover:cursor-pointer"
             width={160}
             height={30}
             onClick={() =>

--- a/components/layouts/sub-sidebar/collected-cafe-detail.tsx
+++ b/components/layouts/sub-sidebar/collected-cafe-detail.tsx
@@ -38,6 +38,7 @@ export default function CollectedCafeDetail({
           </span>
         </div>
         <button
+          aria-label="수집한 카드 상세 정보 보기 취소 버튼"
           onClick={() => setIsSubSidebarOpen(false)}
           className="px-2 right-2"
         >
@@ -50,7 +51,7 @@ export default function CollectedCafeDetail({
           <Image
             src={collectedCafeDetail?.photoUrl}
             alt="카페 썸네일"
-            className="rounded-md"
+            className="w-auto h-auto rounded-md"
             width={160}
             height={30}
           />

--- a/components/layouts/sub-sidebar/location-grid.tsx
+++ b/components/layouts/sub-sidebar/location-grid.tsx
@@ -1,3 +1,6 @@
+import { handleCopyClick } from 'utils/common';
+import { Tooltip } from '@mui/material';
+
 interface LocationGridProps {
   address: string;
 }
@@ -9,7 +12,17 @@ export default function LocationGrid({ address }: LocationGridProps) {
         <i className="fa-solid fa-location-dot pt-1"></i>
         <span>위치</span>
       </div>
-      <div className="col-span-2 text-sm">{address}</div>
+      <div className="col-span-2 flex gap-4">
+        <span className="text-sm">{address}</span>
+        <Tooltip title="복사" placement="right-end">
+          <button
+            onClick={() => handleCopyClick(address)}
+            className="hover:opacity-70"
+          >
+            <i className="fa-solid fa-copy"></i>
+          </button>
+        </Tooltip>
+      </div>
     </div>
   );
 }

--- a/components/layouts/sub-sidebar/memo/memo.tsx
+++ b/components/layouts/sub-sidebar/memo/memo.tsx
@@ -33,6 +33,7 @@ export default function Memo({
             bookmarkedCafeDetail?.name}
         </h2>
         <button
+          aria-label="카드 수집 취소 버튼"
           onClick={() => setMemoOpen(false)}
           className={getMemoBackStyle(isDarkTheme)}
         >
@@ -76,7 +77,11 @@ export default function Memo({
           }}
         />
       </div>
-      <button type="submit" className={getMemoSubmitStyle(isDarkTheme)}>
+      <button
+        aria-label="카드 수집 완료 버튼"
+        type="submit"
+        className={getMemoSubmitStyle(isDarkTheme)}
+      >
         <span className="text-lg">완료</span>
       </button>
     </div>

--- a/components/layouts/sub-sidebar/menu-grid.tsx
+++ b/components/layouts/sub-sidebar/menu-grid.tsx
@@ -21,7 +21,7 @@ export default function MenuGrid({
       <div>
         <div className="flex items-center">
           <span className="text-lg">메뉴</span>
-          <IconButton onClick={handleMenuOpen}>
+          <IconButton aria-label="메뉴 보기 버튼" onClick={handleMenuOpen}>
             {menuOpen ? (
               <i
                 className={`fa-solid fa-angle-up text-md ${isDarkTheme ? 'text-white' : ''}`}

--- a/components/layouts/sub-sidebar/normal-cafe-detail.tsx
+++ b/components/layouts/sub-sidebar/normal-cafe-detail.tsx
@@ -118,9 +118,12 @@ export default function NormalCafeDetail({
           <Image
             src={detail?.photoUrl || '/image/cafe_thumbnail.webp'}
             alt="카페 썸네일"
-            className="rounded-md w-auto h-auto"
+            className="rounded-md w-auto h-auto transform duration-300 ease-out hover:opacity-70 hover:cursor-pointer"
             width={160}
             height={30}
+            onClick={() =>
+              window.open(`http://place.map.kakao.com/${detail?.id}`, '_blank')
+            }
           />
         </div>
 

--- a/components/layouts/sub-sidebar/normal-cafe-detail.tsx
+++ b/components/layouts/sub-sidebar/normal-cafe-detail.tsx
@@ -118,7 +118,7 @@ export default function NormalCafeDetail({
           <Image
             src={detail?.photoUrl || '/image/cafe_thumbnail.webp'}
             alt="카페 썸네일"
-            className="rounded-md w-auto h-auto transform duration-300 ease-out hover:opacity-70 hover:cursor-pointer"
+            className="rounded-md w-auto h-auto transform duration-300 ease-out hover:opacity-30 hover:cursor-pointer"
             width={160}
             height={30}
             onClick={() =>

--- a/components/layouts/sub-sidebar/normal-cafe-detail.tsx
+++ b/components/layouts/sub-sidebar/normal-cafe-detail.tsx
@@ -85,7 +85,7 @@ export default function NormalCafeDetail({
         <div className="flex items-center">
           {isBookmarked ? (
             <IconButton
-              aria-label="bookmark"
+              aria-label="북마크 취소 버튼"
               size="large"
               onClick={() => bookmarkCancelMutation.mutate()}
             >
@@ -93,7 +93,7 @@ export default function NormalCafeDetail({
             </IconButton>
           ) : (
             <IconButton
-              aria-label="bookmark"
+              aria-label="북마크 저장 버튼"
               size="large"
               onClick={() => bookmarkMutation.mutate(detail)}
             >
@@ -105,6 +105,7 @@ export default function NormalCafeDetail({
           <span className="text-2xl font-semibold">{detail?.name}</span>
         </div>
         <button
+          aria-label="카페 상세 정보 보기 취소 버튼"
           onClick={() => setIsSubSidebarOpen(false)}
           className="px-2 right-2"
         >
@@ -117,7 +118,7 @@ export default function NormalCafeDetail({
           <Image
             src={detail?.photoUrl || '/image/cafe_thumbnail.webp'}
             alt="카페 썸네일"
-            className="rounded-md"
+            className="rounded-md w-auto h-auto"
             width={160}
             height={30}
           />
@@ -132,6 +133,7 @@ export default function NormalCafeDetail({
             <CollectedBadge />
           ) : (
             <Button
+              aria-label="수집하기 버튼"
               className={getDetailCollectButtonStyle()}
               variant="contained"
               onClick={() => setMemoOpen(true)}

--- a/components/layouts/sub-sidebar/phone-grid.tsx
+++ b/components/layouts/sub-sidebar/phone-grid.tsx
@@ -1,3 +1,6 @@
+import { handleCopyClick } from 'utils/common';
+import { Tooltip } from '@mui/material';
+
 interface PhoneNumGridProps {
   phoneNum: string | null | undefined;
 }
@@ -9,7 +12,17 @@ export default function PhoneGrid({ phoneNum }: PhoneNumGridProps) {
         <i className="fa-solid fa-phone pt-1"></i>
         <span>전화번호</span>
       </div>
-      <div className="col-span-2 text-lg">{phoneNum}</div>
+      <div className="col-span-2 flex gap-4">
+        <span className="text-lg">{phoneNum}</span>
+        <Tooltip title="복사" placement="right-end">
+          <button
+            onClick={() => handleCopyClick(phoneNum)}
+            className="hover:opacity-70"
+          >
+            <i className="fa-solid fa-copy"></i>
+          </button>
+        </Tooltip>
+      </div>
     </div>
   );
 }

--- a/components/layouts/sub-sidebar/sub-sidebar.tsx
+++ b/components/layouts/sub-sidebar/sub-sidebar.tsx
@@ -26,7 +26,6 @@ export default function SubSidebar() {
   const [eaten, setEaten] = useState('');
   const [concept, setConcept] = useState('');
   const [rating, setRating] = useState(5);
-  const [after500, setAfter500] = useState(false);
 
   const userId = useUserStore((state: any) => state.userId);
 

--- a/components/layouts/sub-sidebar/sub-sidebar.tsx
+++ b/components/layouts/sub-sidebar/sub-sidebar.tsx
@@ -175,12 +175,7 @@ export default function SubSidebar() {
 
   return (
     <Card
-      className={getSubSidebarStyle(
-        isSubSidebarOpen,
-        isDarkTheme,
-        isExtend,
-        after500
-      )}
+      className={getSubSidebarStyle(isSubSidebarOpen, isDarkTheme, isExtend)}
     >
       <div className="flex justify-center">
         <div

--- a/config/auth-provider.tsx
+++ b/config/auth-provider.tsx
@@ -23,6 +23,10 @@ export default function AuthProvider({
       if (session?.access_token !== accessToken) {
         router.refresh();
       }
+
+      if (event === 'SIGNED_OUT' || session?.access_token !== accessToken) {
+        router.refresh();
+      }
     });
 
     return () => {

--- a/hooks/useThrottle.tsx
+++ b/hooks/useThrottle.tsx
@@ -1,0 +1,24 @@
+import { useCallback, useRef } from 'react';
+
+type useThrottleParams<T extends (...args: any[]) => void> = {
+  callback: T;
+  delay: number;
+};
+
+export default function useThrottle<T extends (...args: any[]) => void>({
+  callback,
+  delay,
+}: useThrottleParams<T>) {
+  const lastRun = useRef(Date.now());
+
+  return useCallback(
+    (...args: Parameters<T>) => {
+      const timeElapsed = Date.now() - lastRun.current;
+      if (timeElapsed >= delay) {
+        callback(...args);
+        lastRun.current = Date.now();
+      }
+    },
+    [callback, delay]
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,7 +16,7 @@ const config: Config = {
         darkbg: '#1f1926',
         darkaccent: '#5f018a',
 
-        success: '#15ed79',
+        success: '#09d665',
         indigo: '#6366f1',
 
         beginner: '#8a919c',

--- a/utils/common.ts
+++ b/utils/common.ts
@@ -1,10 +1,8 @@
-import { toast } from 'react-toastify';
-
 export const handleCopyClick = async (param: any) => {
   try {
     await navigator.clipboard.writeText(param);
-    toast.success('클립보드에 복사되었습니다!');
+    alert('클립보드에 복사되었습니다!');
   } catch (error) {
-    toast.error('다시 시도해주세요.');
+    alert('다시 시도해주세요.');
   }
 };

--- a/utils/common.ts
+++ b/utils/common.ts
@@ -1,0 +1,10 @@
+import { toast } from 'react-toastify';
+
+export const handleCopyClick = async (param: any) => {
+  try {
+    await navigator.clipboard.writeText(param);
+    toast.success('클립보드에 복사되었습니다!');
+  } catch (error) {
+    toast.error('다시 시도해주세요.');
+  }
+};

--- a/utils/store.ts
+++ b/utils/store.ts
@@ -61,8 +61,10 @@ export const useUserStore = create(
   persist(
     (set: any) => ({
       userId: null,
+      userEmail: '새로고침 하기',
       userTier: 'BEGINNER',
       setUserId: (user: string) => set({ userId: user }),
+      setUserEmail: (user: string) => set({ userEmail: user }),
       setUserTier: (tier: string) => set({ userTier: tier }),
     }),
     {
@@ -70,6 +72,7 @@ export const useUserStore = create(
       getStorage: () => localStorage,
       partialize: (state: any) => ({
         userId: state.userId,
+        userEmail: state.userEmail,
         userTier: state.userTier,
       }),
       merge: (persistedState: any, currentState: any) => ({

--- a/utils/styles.ts
+++ b/utils/styles.ts
@@ -132,3 +132,18 @@ export const getRatingStarStyle = () => {
 export const getLogoutButtonStyle = () => {
   return 'bg-main rounded-xl shadow-md w-[12rem] sm:w-[10rem] py-4 sm:py-2 hover:bg-opacity-70 transition duration-300 ease-in';
 };
+
+export const getAuthFormCardStyle = () => {
+  return 'p-5 rounded-xl bg-white shadow-mainShadow z-10';
+};
+
+export const getAuthFormTitleStyle = () => {
+  return 'text-center text-3xl font-bold font-dpixel';
+};
+export const getAuthFormMentionStyle = () => {
+  return 'flex items-center justify-center gap-4 text-center font-dpixel';
+};
+
+export const getKakaoButtonStyle = () => {
+  return 'bg-yellow-500 w-full hover:bg-opacity-70 hover:cursor-pointer';
+};

--- a/utils/styles.ts
+++ b/utils/styles.ts
@@ -83,7 +83,7 @@ export const getExpertTierStyle = (addOn: string = '') => {
 };
 
 export const getMasterEffectStyle = (width: string) => {
-  return `${width} z-0 absolute inset-0 h-8 bg-gradient-to-r from-master-effect-left via-master-effect-mid to-master-effect-right rounded-xl blur-sm animate-tilt`;
+  return `${width} z-0 absolute inset-0 h-9 bg-gradient-to-r from-master-effect-left via-master-effect-mid to-master-effect-right rounded-xl blur-sm animate-tilt`;
 };
 
 export const getMasterTierStyle = (addOn: string = '') => {

--- a/utils/supabase/signinKakao.ts
+++ b/utils/supabase/signinKakao.ts
@@ -9,7 +9,7 @@ export const signInWithKakao = async () => {
     provider: 'kakao',
     options: {
       redirectTo: process.env.NEXT_PUBLIC_API_REQUEST_URI
-        ? `https://${process.env.NEXT_PUBLIC_API_REQUEST_URI}/auth/callback`
+        ? `${process.env.NEXT_PUBLIC_API_REQUEST_URI}/auth/callback`
         : 'http://localhost:3000/auth/callback',
     },
   });


### PR DESCRIPTION
<h2>비밀번호 재설정 기능 구현 및 버그 수정</h2>
supabase는 updateUser가 성공하면 자동으로 로그인 처리를 한다. 그래서 자꾸 멋대로 MainLayout이 렌더링 되어서
새로운 페이지 /resetpassword/complete를 하나 만들어서 UI/UX를 의도대로 수정함.

<h2>Image 태그 w-auto, h-auto 추가. 버튼 태그 aria-label 추가.</h2> 
Image 태그 경고 메세지 픽스. 모든 버튼에 간접 SEO를 위한 aria-label 속성 추가.

<h2>useThrottle 커스텀 훅 생성. 주소/전화번호 클립보드 복사 기능 구현. 썸네일 이미지 클릭시 카카오 플레이스로 이동</h2>
useThrottle은 아직 사용하지 않는 중. 상세 정보에서 주소와 전화번호를 손쉽게 복사할 수 있게 기능 추가.
그리고 썸네일 이미지를 클릭하면 카카오 플레이스에서 제공하는 페이지로 이동하게 수정.

<h2>UI 수정</h2>
티어 모달 md 사이즈일 때 width 수정 및 기타 반복되는 스타일 패턴 style.ts에 정리