### PR TITLE
Feature

### DIFF
--- a/components/layouts/sidebar/footer/tier-info-modal.tsx
+++ b/components/layouts/sidebar/footer/tier-info-modal.tsx
@@ -2,8 +2,8 @@ import { useCheckStore } from 'utils/store';
 import {
   getBadgeCommon,
   getExpertTierStyle,
-  getMasterEffectStyle,
   getMasterTierStyle,
+  getModalMasterEffectStyle,
 } from 'utils/styles';
 import { Box, Modal } from '@mui/material';
 import { BadgeProps } from 'types/types';
@@ -98,7 +98,7 @@ export default function TierInfoModal({
             어엿한 카페 고수입니다 뿌듯하셔도 좋아요!!
           </span>
           <div className="relative flex items-center gap-3">
-            <div className={getMasterEffectStyle('w-[11%]')}></div>
+            <div className={getModalMasterEffectStyle()}></div>
             <div className={getMasterTierStyle(getBadgeCommon)}>
               <span className="text-sm font-dpixel">MASTER</span>
             </div>

--- a/utils/styles.ts
+++ b/utils/styles.ts
@@ -86,6 +86,10 @@ export const getMasterEffectStyle = (width: string) => {
   return `${width} z-0 absolute inset-0 h-9 bg-gradient-to-r from-master-effect-left via-master-effect-mid to-master-effect-right rounded-xl blur-sm animate-tilt`;
 };
 
+export const getModalMasterEffectStyle = () => {
+  return `w-[27%] sm:w-[9%] z-0 absolute -top-0.5 inset-0 h-9 bg-gradient-to-r from-master-effect-left via-master-effect-mid to-master-effect-right rounded-xl blur-sm animate-tilt`;
+};
+
 export const getMasterTierStyle = (addOn: string = '') => {
   return `${addOn} z-10 relative bg-gradient-to-r from-master-side via-master-via to-master-side bg-[length:200%_200%] animate-gradient text-white shadow-md`;
 };

--- a/utils/supabase/signinKakao.ts
+++ b/utils/supabase/signinKakao.ts
@@ -8,9 +8,7 @@ export const signInWithKakao = async () => {
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: 'kakao',
     options: {
-      redirectTo: process.env.NEXT_PUBLIC_API_REQUEST_URI
-        ? `${process.env.NEXT_PUBLIC_API_REQUEST_URI}/auth/callback`
-        : 'http://localhost:3000/auth/callback',
+      redirectTo: `${process.env.NEXT_PUBLIC_API_REQUEST_URI}/auth/callback`,
     },
   });
 


### PR DESCRIPTION
<h2>카카오 리다이렉트 수정</h2>
환경변수로만 제어하는 것으로 수정.

<h2>티어 정보 모달과 프로필 뱃지의 마스터 이펙트 분리</h2>
하나의 get 함수에 파라미터로 전달받아 w-[%]를 설정하는 게 티어 모달에서 계속 문제를 일으켜, 별도의 get 함수로 분리.