### PR TITLE
[Code] 서버/클라이언트 레이아웃 모듈 분리

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,17 +1,13 @@
 import { createServerSupabaseClient } from 'utils/supabase/server';
 import { AuthViewProvider } from 'config/auth-view-provider';
-import { ToastContainer } from 'react-toastify';
 import { Metadata } from 'next';
+import './globals.css';
+import React from 'react';
+import localFont from 'next/font/local';
 import ReactQueryClientProvider from 'config/react-query-client-provider';
 import AuthProvider from 'config/auth-provider';
-import './globals.css';
-import 'react-toastify/dist/ReactToastify.css';
-import React from 'react';
-import dynamic from 'next/dynamic';
-import Auth from 'components/auth/shared';
 import MainLayout from 'components/layouts/main-layout';
-import KakaoMap from 'components/layouts/kakaomap';
-import localFont from 'next/font/local';
+import Auth from 'components/auth/shared';
 
 const dungGeunMo = localFont({
   src: './fonts/DungGeunMo.woff',
@@ -19,14 +15,6 @@ const dungGeunMo = localFont({
   style: 'normal',
   variable: '--font-dpixel',
 });
-
-const ReactQueryDevtools = dynamic(
-  () =>
-    import('@tanstack/react-query-devtools').then(
-      mod => mod.ReactQueryDevtools,
-    ),
-  { ssr: false },
-);
 
 export const metadata: Metadata = {
   title: 'Cafe Masters',
@@ -61,7 +49,6 @@ export default async function RootLayout({
 }>) {
   const supabase = await createServerSupabaseClient();
 
-  const isDev = process.env.NEXT_THIS_ENV === 'develope';
   const isTesting = process.env.NEXT_IS_TESTING === 'test';
 
   const {
@@ -76,19 +63,7 @@ export default async function RootLayout({
             accessToken={session?.access_token ?? 'no-access-token'}
           >
             {session?.user || isTesting ? (
-              <MainLayout>
-                {children}
-                <KakaoMap />
-                <ToastContainer
-                  position="top-center"
-                  autoClose={2000}
-                  newestOnTop={false}
-                  draggable
-                  theme="light"
-                  limit={1}
-                />
-                {isDev && <ReactQueryDevtools initialIsOpen={false} />}
-              </MainLayout>
+              <MainLayout>{children}</MainLayout>
             ) : (
               <AuthViewProvider>
                 <Auth />

--- a/components/layouts/kakaomap/index.tsx
+++ b/components/layouts/kakaomap/index.tsx
@@ -43,6 +43,7 @@ export default function KakaoMap() {
     const script = document.createElement('script');
     script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_KEY}&libraries=services&autoload=false`;
     script.async = true;
+    script.defer = true;
     document.head.appendChild(script);
 
     script.onload = () => {
@@ -53,7 +54,7 @@ export default function KakaoMap() {
             37.54715716085294,
             127.04663357436208,
           ),
-          level: 5,
+          level: 7,
         };
         const zoomControl = new window.kakao.maps.ZoomControl();
 
@@ -246,5 +247,5 @@ export default function KakaoMap() {
     collectedCafe,
   ]);
 
-  return <div id="map" className={KakaoMapStyle} />;
+  return <div id="map" className={KakaoMapStyle}></div>;
 }

--- a/components/layouts/main-layout.tsx
+++ b/components/layouts/main-layout.tsx
@@ -1,13 +1,33 @@
 'use client';
 
 import { ReactNode, useEffect } from 'react';
+import dynamic from 'next/dynamic';
 import Sidebar from 'components/layouts/sidebar/container';
+
+const KakaoMap = dynamic(() => import('components/layouts/kakaomap'), {
+  ssr: false,
+});
+
+const ReactQueryDevtools = dynamic(
+  () =>
+    import('@tanstack/react-query-devtools').then(
+      mod => mod.ReactQueryDevtools,
+    ),
+  { ssr: false },
+);
+
+const ToastContainer = dynamic(
+  () => import('react-toastify').then(mod => mod.ToastContainer),
+  { ssr: false },
+);
 
 interface MainLayout {
   children: ReactNode;
 }
 
 export default function MainLayout({ children }: MainLayout) {
+  const isDev = process.env.NEXT_PUBLIC_THIS_ENV === 'develope';
+
   useEffect(() => {
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/sw.js').then(registration => {
@@ -20,6 +40,16 @@ export default function MainLayout({ children }: MainLayout) {
     <main className="flex">
       <Sidebar />
       {children}
+      <KakaoMap />
+      <ToastContainer
+        position="top-center"
+        autoClose={2000}
+        newestOnTop={false}
+        draggable
+        theme="light"
+        limit={1}
+      />
+      {isDev && <ReactQueryDevtools initialIsOpen={false} />}
     </main>
   );
 }

--- a/components/layouts/sidebar/main/collected-cafe.tsx
+++ b/components/layouts/sidebar/main/collected-cafe.tsx
@@ -68,8 +68,8 @@ export default function CollectedCafe({
         </div>
         <div className="flex justify-center rounded-xl">
           <Image
-            src={photoUrl ?? ''}
-            alt="카페 썸네일 이미지"
+            src={photoUrl ?? '/image/cafe_thumbnail.webp'}
+            alt="카페 썸네일"
             width={100}
             height={50}
             className="w-auto h-auto"

--- a/components/layouts/sidebar/main/normal-cafe.tsx
+++ b/components/layouts/sidebar/main/normal-cafe.tsx
@@ -27,7 +27,7 @@ export default function NormalCafe({
       <div className="flex justify-center">
         <Image
           src="https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters/search_thumbnail.webp"
-          alt="카페 썸네일 이미지"
+          alt="카페 썸네일"
           width={100}
           height={50}
           priority={true}


### PR DESCRIPTION
카카오맵, 토스트 컨테이너, 리액트 쿼리데브툴은 메인 레이아웃에서 레이지 로딩 적용