### PR TITLE
3 commits

### DIFF
--- a/app/resetpassword/page.tsx
+++ b/app/resetpassword/page.tsx
@@ -22,6 +22,8 @@ export default function ResetpasswordPage() {
   const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     finishResetMutation.mutate(newPassword);
+    alert('비밀번호를 재설정했습니다!');
+    router.push('/resetpassword/complete');
   };
 
   const handleCancel = async (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/components/auth/signup/index.tsx
+++ b/components/auth/signup/index.tsx
@@ -50,6 +50,7 @@ export default function Signup() {
     if (confirmationRequired) {
       verifyOtpMutation.mutate({ email, otp });
       setConfirmationRequired(true);
+      alert('회원가입이 완료되었습니다');
     } else handleSignup();
   };
 

--- a/components/layouts/main-layout.tsx
+++ b/components/layouts/main-layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactNode } from 'react';
+import 'react-toastify/dist/ReactToastify.css';
 import dynamic from 'next/dynamic';
 import Sidebar from 'components/layouts/sidebar/container';
 

--- a/components/layouts/sidebar/sub-sidebar/collected-cafe/detail.tsx
+++ b/components/layouts/sidebar/sub-sidebar/collected-cafe/detail.tsx
@@ -66,6 +66,7 @@ export default function CollectedCafeDetail({ setMemoOpen }: CafeDetailProps) {
             className="rounded-md w-auto h-auto transform duration-300 ease-out hover:opacity-30 hover:cursor-pointer"
             width={160}
             height={30}
+            priority={true}
             onClick={() =>
               window.open(
                 `http://place.map.kakao.com/${collectedCafeDetail?.id}`,

--- a/components/layouts/sidebar/sub-sidebar/container.tsx
+++ b/components/layouts/sidebar/sub-sidebar/container.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useCheckStore, useMapStore, useUserStore } from 'utils/store';
 import { useUploadCollectMutation } from 'hooks/useUploadCollectMutation';
 import { useUpdateCollectMutation } from 'hooks/useUpdateCollectMutation';
 import { getSubSidebarStyle } from 'utils/styles';
 import { CollectedRowInsert, CollectedRowUpdate } from 'actions/collectActions';
+import { toast } from 'react-toastify';
 import Memo from './memo';
 import NormalCafeDetail from './normal-cafe/detail';
 import CollectedCafeDetail from './collected-cafe/detail';
@@ -41,6 +42,7 @@ export default function SubSidebar() {
   const isExtend = useCheckStore(state => state.isExtend);
 
   const pathname = usePathname();
+  const router = useRouter();
 
   const detail = {
     id: cafeDetail?.basicInfo?.cid ?? 0,
@@ -82,6 +84,17 @@ export default function SubSidebar() {
     coordX: thisX,
     coordY: thisY,
   };
+
+  useEffect(() => {
+    if (pathname.startsWith('/cafe/collected') && collectedCafeDetail) {
+      setComment(collectedCafeDetail.comment || '');
+      setPros(collectedCafeDetail.pros || '');
+      setCons(collectedCafeDetail.cons || '');
+      setEaten(collectedCafeDetail.eaten || '');
+      setConcept(collectedCafeDetail.concept || '');
+      setRating(collectedCafeDetail.rating || 5);
+    }
+  }, [pathname, collectedCafeDetail]);
 
   useEffect(() => {
     setCurrentName(
@@ -144,34 +157,31 @@ export default function SubSidebar() {
 
   const updateCollectMutation = useUpdateCollectMutation();
 
-  const handleUploadCollect = (newMemo: CollectedRowInsert) => {
-    setMemoOpen(false);
-    uploadCollectMutation.mutate(newMemo);
-  };
-
-  const handleUpdateCollect = (memo: CollectedRowUpdate) => {
-    setMemoOpen(false);
-    updateCollectMutation.mutate(memo);
-  };
-
   const handleMenuOpen = () => {
     if (isMenuOpen === false) setIsMenuOpen(true);
     else setIsMenuOpen(false);
   };
 
-  if ((pathname.startsWith('/cafe/all/detail') && !cafeDetail) || !userId)
+  const handleUploadCollect = (newMemo: CollectedRowInsert) => {
+    setMemoOpen(false);
+    uploadCollectMutation.mutate(newMemo);
+    toast.success('카드를 수집했습니다!');
+    router.refresh();
+  };
+
+  const handleUpdateCollect = (memo: CollectedRowUpdate) => {
+    setMemoOpen(false);
+    updateCollectMutation.mutate(memo);
+    toast.success('카드의 스펙을 수정했습니다!');
+    router.refresh();
+  };
+
+  if (pathname.startsWith('/cafe/all/detail') && !cafeDetail) return null;
+
+  if (pathname.startsWith('/cafe/collected/detail') && !collectedCafeDetail)
     return null;
 
-  if (
-    (pathname.startsWith('/cafe/collected/detail') && !collectedCafeDetail) ||
-    !userId
-  )
-    return null;
-
-  if (
-    (pathname.startsWith('/cafe/bookmarked/detail') && !bookmarkedCafeDetail) ||
-    !userId
-  )
+  if (pathname.startsWith('/cafe/bookmarked/detail') && !bookmarkedCafeDetail)
     return null;
 
   return (
@@ -229,6 +239,11 @@ export default function SubSidebar() {
             detail={detail}
             collectedCafeDetail={collectedCafeDetail}
             bookmarkedCafeDetail={bookmarkedCafeDetail}
+            comment={comment}
+            pros={pros}
+            cons={cons}
+            eaten={eaten}
+            concept={concept}
             setComment={setComment}
             setPros={setPros}
             setCons={setCons}

--- a/components/layouts/sidebar/sub-sidebar/container.tsx
+++ b/components/layouts/sidebar/sub-sidebar/container.tsx
@@ -14,6 +14,7 @@ import CollectedCafeDetail from './collected-cafe/detail';
 
 export default function SubSidebar() {
   const [memoOpen, setMemoOpen] = useState(false);
+  const [id, setId] = useState<string | undefined>('');
   const [comment, setComment] = useState('');
   const [pros, setPros] = useState('');
   const [cons, setCons] = useState('');
@@ -103,6 +104,31 @@ export default function SubSidebar() {
       setRating(5);
     }
   }, [pathname, collectedCafeDetail]);
+
+  useEffect(() => {
+    // 새로운 id 값 설정
+    const newId =
+      pathname.startsWith('/cafe/all') && detail?.id
+        ? detail?.id
+        : pathname.startsWith('/cafe/collected') && collectedCafeDetail?.id
+          ? collectedCafeDetail?.id
+          : pathname.startsWith('/cafe/bookmarked') && bookmarkedCafeDetail?.id
+            ? bookmarkedCafeDetail?.id
+            : null;
+
+    const strId = newId?.toString();
+
+    if (strId !== id) {
+      setId(strId); // id 업데이트
+      setMemoOpen(false); // id 변경 시 memoOpen 닫기
+    }
+  }, [
+    pathname,
+    detail?.id,
+    collectedCafeDetail?.id,
+    bookmarkedCafeDetail?.id,
+    id,
+  ]);
 
   const memoFromDetail = {
     id: detail?.id,

--- a/components/layouts/sidebar/sub-sidebar/container.tsx
+++ b/components/layouts/sidebar/sub-sidebar/container.tsx
@@ -20,7 +20,6 @@ export default function SubSidebar() {
   const [eaten, setEaten] = useState('');
   const [concept, setConcept] = useState('');
   const [rating, setRating] = useState(5);
-  const [currentName, setCurrentName] = useState('');
 
   const cafeDetail = useMapStore(state => state.cafeDetail);
   const collectedCafeDetail = useMapStore(
@@ -94,17 +93,16 @@ export default function SubSidebar() {
       setConcept(collectedCafeDetail.concept || '');
       setRating(collectedCafeDetail.rating || 5);
     }
+
+    if (!pathname.startsWith('/cafe/collected')) {
+      setComment('');
+      setPros('');
+      setCons('');
+      setEaten('');
+      setConcept('');
+      setRating(5);
+    }
   }, [pathname, collectedCafeDetail]);
-
-  useEffect(() => {
-    setCurrentName(
-      detail?.name || collectedCafeDetail?.name || bookmarkedCafeDetail?.name,
-    );
-  }, [detail?.name, collectedCafeDetail?.name, bookmarkedCafeDetail?.name]);
-
-  useEffect(() => {
-    setMemoOpen(false);
-  }, [currentName]);
 
   const memoFromDetail = {
     id: detail?.id,
@@ -171,6 +169,11 @@ export default function SubSidebar() {
 
   const handleUpdateCollect = (memo: CollectedRowUpdate) => {
     setMemoOpen(false);
+    setComment('');
+    setPros('');
+    setCons('');
+    setEaten('');
+    setConcept('');
     updateCollectMutation.mutate(memo);
     toast.success('카드의 스펙을 수정했습니다!');
     router.refresh();

--- a/components/layouts/sidebar/sub-sidebar/memo/index.tsx
+++ b/components/layouts/sidebar/sub-sidebar/memo/index.tsx
@@ -13,6 +13,11 @@ export default function Memo({
   detail,
   collectedCafeDetail,
   bookmarkedCafeDetail,
+  comment,
+  pros,
+  cons,
+  eaten,
+  concept,
   setComment,
   setPros,
   setCons,
@@ -44,28 +49,33 @@ export default function Memo({
       </div>
       <input
         required
+        value={comment}
         placeholder="내 코멘트(필수)"
         onChange={e => setComment(e.target.value)}
         className={getMemoInputStyle(isDarkTheme)}
       />
       <input
+        value={pros}
         placeholder="좋은 점"
         onChange={e => setPros(e.target.value)}
         className={getMemoInputStyle(isDarkTheme)}
       />
       <input
         placeholder="별로인 점"
+        value={cons}
         onChange={e => setCons(e.target.value)}
         className={getMemoInputStyle(isDarkTheme)}
       />
       <input
         required
+        value={eaten}
         placeholder="먹어본 메뉴(필수)"
         onChange={e => setEaten(e.target.value)}
         className={getMemoInputStyle(isDarkTheme)}
       />
       <input
         placeholder="카페의 컨셉"
+        value={concept}
         onChange={e => setConcept(e.target.value)}
         className={getMemoInputStyle(isDarkTheme)}
       />

--- a/components/layouts/sidebar/sub-sidebar/normal-cafe/detail.tsx
+++ b/components/layouts/sidebar/sub-sidebar/normal-cafe/detail.tsx
@@ -11,6 +11,7 @@ import {
 } from 'utils/styles';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleXmark } from '@fortawesome/free-solid-svg-icons';
+import { toast } from 'react-toastify';
 import CollectedBadge from 'components/layouts/sidebar/sub-sidebar/normal-cafe/collected-badge';
 import ReviewAndRatingGrid from './review-and-rating-grid';
 import Image from 'next/image';
@@ -49,9 +50,17 @@ export default function NormalCafeDetail({
 
   const cancelBookmarkMutation = useCancelBookmarkMutation();
 
+  const handleUploadBookmark = () => {
+    uploadBookmarkMutation.mutate(detail);
+    toast.success('가고 싶은 카페를 북마크했습니다!');
+    router.refresh();
+  };
+
   const handleCancelBookmark = () => {
     cancelBookmarkMutation.mutate();
     setIsSubSidebarOpen(false);
+    toast.success('가고 싶은 카페를 제거했습니다!');
+    router.push('/cafe/bookmarked');
   };
 
   const handleSetIsSubSidebarOpen = () => {
@@ -75,7 +84,7 @@ export default function NormalCafeDetail({
           ) : (
             <button
               aria-label="북마크 저장 버튼"
-              onClick={() => uploadBookmarkMutation.mutate(detail)}
+              onClick={handleUploadBookmark}
             >
               <BookmarkIcon
                 className={`hover:scale-110 ${isDarkTheme ? 'text-white' : ''}`}

--- a/hooks/useCancelBookmarkMutation.ts
+++ b/hooks/useCancelBookmarkMutation.ts
@@ -1,8 +1,6 @@
-import { useRouter } from 'next/navigation';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMapStore, useUserStore } from 'utils/store';
 import { deleteBookmarkedCafe } from 'actions/bookmarkActions';
-import { toast } from 'react-toastify';
 
 export function useCancelBookmarkMutation() {
   const bookmarkedCafeDetail = useMapStore(
@@ -10,8 +8,6 @@ export function useCancelBookmarkMutation() {
   );
 
   const userId = useUserStore(state => state.userId);
-
-  const router = useRouter();
 
   const queryClient = useQueryClient();
 
@@ -21,12 +17,7 @@ export function useCancelBookmarkMutation() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['bookmarkedCafe', userId] });
       queryClient.refetchQueries({ queryKey: ['bookmarkedCafe', userId] });
-      toast.success('북마크에서 제거했습니다!');
-      router.push('/cafe/bookmarked');
     },
-    onError: error => {
-      console.error(error);
-      toast.error('북마크에서 제거하는데 문제가 발생했습니다');
-    },
+    onError: error => console.error(error),
   });
 }

--- a/hooks/useFinishResetMutation.ts
+++ b/hooks/useFinishResetMutation.ts
@@ -1,9 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
 import { createBrowserSupabaseClient } from 'utils/supabase/client';
 
 export function useFinishResetMutation() {
-  const router = useRouter();
   const supabase = createBrowserSupabaseClient();
 
   return useMutation({
@@ -14,14 +12,12 @@ export function useFinishResetMutation() {
 
       if (error) throw new Error(error.message);
     },
-    onError: (error: Error) => {
-      console.error(error);
-      alert('새로운 비밀번호는 기존 비밀번호와 달라야합니다.');
-    },
     onSuccess: async () => {
       await supabase.auth.signOut();
-      alert('비밀번호를 재설정했습니다!');
-      router.push('/resetpassword/complete');
+    },
+    onError: error => {
+      console.error(error);
+      alert('새로운 비밀번호는 기존 비밀번호와 달라야합니다.');
     },
   });
 }

--- a/hooks/useResetPasswordMutation.ts
+++ b/hooks/useResetPasswordMutation.ts
@@ -13,9 +13,9 @@ export function useResetPasswordMutation() {
       return '이메일의 보관함을 확인해주세요.';
     },
 
-    onError: (error: Error) => {
+    onError: error => {
       console.error(error, error.message);
-      alert('재요청은 60초가 지나야 가능합니다.');
+      alert('재요청은 이전 요청 60초 후 가능합니다.');
     },
   });
 }

--- a/hooks/useSigninMutation.ts
+++ b/hooks/useSigninMutation.ts
@@ -20,7 +20,7 @@ export function useSigninMutation() {
       if (error) throw new Error(error.message);
     },
 
-    onError: (error: Error) => {
+    onError: error => {
       if (error.message) alert('이메일 또는 비밀번호를 잘못 입력했습니다.');
       else alert('알 수 없는 에러가 발생했습니다.');
     },

--- a/hooks/useSignupMutation.ts
+++ b/hooks/useSignupMutation.ts
@@ -23,6 +23,6 @@ export function useSignupMutation() {
       if (error) throw new Error(error.message);
     },
 
-    onError: (error: Error) => console.error(error),
+    onError: error => console.error(error),
   });
 }

--- a/hooks/useUpdateCollectMutation.ts
+++ b/hooks/useUpdateCollectMutation.ts
@@ -1,18 +1,14 @@
-import { useRouter } from 'next/navigation';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { useMapStore, useUserStore } from 'utils/store';
 import {
   CollectedRowUpdate,
   updateCollectedCafe,
 } from 'actions/collectActions';
-import { toast } from 'react-toastify';
 
 export function useUpdateCollectMutation() {
   const userId = useUserStore(state => state.userId);
 
   const queryClient = useQueryClient();
-
-  const router = useRouter();
 
   const collectedCafeDetail = useMapStore(
     state => state.collectedCafeDetail[0],
@@ -24,8 +20,6 @@ export function useUpdateCollectMutation() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['collectedCafe', userId] });
       queryClient.refetchQueries({ queryKey: ['collectedCafe', userId] });
-      toast.success('카드의 스펙을 수정했습니다!');
-      router.refresh();
     },
     onError: error => console.error(error),
   });

--- a/hooks/useUploadBookmarkMutation.ts
+++ b/hooks/useUploadBookmarkMutation.ts
@@ -1,16 +1,12 @@
-import { useRouter } from 'next/navigation';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useUserStore } from 'utils/store';
 import {
   BookmarkedRowInsert,
   createBookmarkedCafe,
 } from 'actions/bookmarkActions';
-import { toast } from 'react-toastify';
 
 export function useUploadBookmarkMutation() {
   const userId = useUserStore(state => state.userId);
-
-  const router = useRouter();
 
   const queryClient = useQueryClient();
 
@@ -20,8 +16,6 @@ export function useUploadBookmarkMutation() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['bookmarkedCafe', userId] });
       queryClient.refetchQueries({ queryKey: ['bookmarkedCafe', userId] });
-      toast.success('새로운 카페를 북마크에 저장했습니다!');
-      router.refresh();
     },
     onError: error => console.error(error),
   });

--- a/hooks/useUploadCollectMutation.ts
+++ b/hooks/useUploadCollectMutation.ts
@@ -1,18 +1,14 @@
-import { useRouter } from 'next/navigation';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { useUserStore } from 'utils/store';
 import {
   CollectedRowInsert,
   createCollectedCafe,
 } from 'actions/collectActions';
-import { toast } from 'react-toastify';
 
 export function useUploadCollectMutation() {
   const userId = useUserStore(state => state.userId);
 
   const queryClient = useQueryClient();
-
-  const router = useRouter();
 
   return useMutation({
     mutationFn: async (memo: CollectedRowInsert) =>
@@ -20,8 +16,6 @@ export function useUploadCollectMutation() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['collectedCafe', userId] });
       queryClient.refetchQueries({ queryKey: ['collectedCafe', userId] });
-      toast.success(`새로운 카드를 수집했습니다!`);
-      router.refresh();
     },
     onError: error => console.error(error),
   });

--- a/hooks/useVerifyOtpMutation.ts
+++ b/hooks/useVerifyOtpMutation.ts
@@ -15,6 +15,6 @@ export default function useVerifyOtpMutation() {
       if (error) throw new Error(error.message);
     },
 
-    onError: (error: Error) => console.error(error),
+    onError: error => console.error(error),
   });
 }

--- a/types/common.ts
+++ b/types/common.ts
@@ -117,6 +117,11 @@ export interface MemoProps {
   detail: NormalCafeDetailForUpload;
   collectedCafeDetail: CollectedCafeDetailForUpload;
   bookmarkedCafeDetail: NormalCafeDetailForUpload;
+  comment: string;
+  pros: string;
+  cons: string;
+  eaten: string;
+  concept: string;
   setComment: (comment: string) => void;
   setPros: (pros: string) => void;
   setCons: (cons: string) => void;


### PR DESCRIPTION
<h2>수집한 카드 수정시 초기값 로드</h2>
expired

<h2>useMutation 훅의 성공시 내부 로직 단순화</h2>
onSuccess에 router.push(경로 이동), toast.success(UI 윈도우) 이벤트를 삭제하고<br/>
훅을 사용하는 핸들러 함수에서 처리하도록 로직 변경