### PR TITLE
[Refactor] 랜딩 페이지 반응형 개선, 유틸 함수 이동, 사이드바 스크롤 해결

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,12 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 
-function Navbar() {
+/**
+ * 반응형 스타일 참고
+ * @params 1100, 1020, 690, 560
+ */
+
+const Navbar = () => {
   const router = useRouter();
 
   const handleRouteSignin = () => router.push('/auth');
@@ -20,7 +25,7 @@ function Navbar() {
             className="w-[2rem] h-auto"
             priority={true}
           />
-          <span className="text-3xl text-white text-shadow-black font-pretendard font-bold">
+          <span className="text-3xl max-[560px]:text-xl text-white text-shadow-black font-pretendard font-bold">
             Cafe Masters
           </span>
         </div>
@@ -35,9 +40,9 @@ function Navbar() {
       </div>
     </section>
   );
-}
+};
 
-function ScrollSections() {
+const ScrollSections = () => {
   const [activeIndex, setActiveIndex] = useState(0);
 
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -48,7 +53,7 @@ function ScrollSections() {
       title: '여러분만의 카드를\n수집하세요',
       subtitle: '01',
       description:
-        '마스터즈 월드에서는 여러분이 찾는 모든 카페가 있습니다.\n내가 가 본 카페를 수집해 마스터가 되세요!',
+        '마스터즈 월드에는 모든 카페가 있습니다.\n여러분이 갔던 카페를 수집해 마스터가 되세요!',
       imageUrl: '/image/scroll_section.avif',
     },
     {
@@ -56,7 +61,7 @@ function ScrollSections() {
       title: '가보고 싶은 곳을\n저장해두세요',
       subtitle: '02',
       description:
-        '마음에 드는 카페가 있는데 막상 가기전에 생각이 안 날 때가 있죠?\n북마크로 저장하고 잊지 마세요!',
+        '어딜 가려고 했는지 생각이 안 날 때가 있죠?\n북마크로 저장하고 잊지 마세요!',
       imageUrl: '/image/scroll_section_1.avif',
     },
     {
@@ -109,21 +114,21 @@ function ScrollSections() {
       {sections.map((section, index) => (
         <section
           key={section.id}
-          className="relative h-full scroll-section flex flex-col md:flex-row"
+          className="relative h-full scroll-section flex max-[1020px]:flex-col"
         >
           {index !== 1 ? (
             <>
-              <div className="group relative overflow-hidden w-full md:w-1/2 h-1/2 md:h-full before:content-[''] before:absolute before:top-0 before:left-0 before:w-full before:h-full before:bg-gradient-to-r before:from-neutral-950/70 before:to-neutral-950/50 before:transition-opacity before:duration-500 hover:before:opacity-0">
+              <div className="group relative max-[1020px]:w-full w-1/2 max-[1020px] h-1/2 md:h-full overflow-hidden before:content-[''] before:absolute before:top-0 before:left-0 before:w-full before:h-full before:bg-gradient-to-r before:from-neutral-950/70 before:to-neutral-950/50 before:transition-opacity before:duration-500 hover:before:opacity-0">
                 <Image
                   src={section.imageUrl}
                   alt={section.title}
                   fill
                   sizes="(max-width: 1200px) 100vh, 50vw"
-                  className="absolute inset-0 w-full h-full object-cover saturate-150 transition-all duration-1000 group-hover:scale-110 group-hover:rotate-1"
+                  className="absolute inset-0 w-full h-full object-cover saturate-150 group-hover:scale-110 group-hover:rotate-1 transition-all duration-1000"
                   priority={true}
                 />
               </div>
-              <div className="w-full whitespace-nowrap md:w-1/2 h-1/2 md:h-full flex items-center justify-center p-8 bg-neutral-950">
+              <div className="max-[1020px]:w-full w-1/2 max-[1020px] h-1/2 md:h-full p-8 whitespace-nowrap flex items-center justify-center bg-neutral-950">
                 <div className="max-w-lg animate-float">
                   <span className="text-neutral-400 tracking-wider text-sm font-mono">
                     {section.subtitle.split('\n').map((text, index) => (
@@ -133,7 +138,7 @@ function ScrollSections() {
                       </span>
                     ))}
                   </span>
-                  <h2 className="mt-4 leading-none bg-gradient-to-r from-white to-neutral-400 bg-clip-text text-5xl md:text-7xl font-bold text-transparent">
+                  <h2 className="mt-4 leading-none bg-gradient-to-r from-white to-neutral-400 bg-clip-text text-6xl max-[1100px]:text-4xl font-bold text-transparent">
                     {section.title.split('\n').map((text, index) => (
                       <span key={index}>
                         {text}
@@ -154,7 +159,7 @@ function ScrollSections() {
             </>
           ) : (
             <>
-              <div className="w-full md:w-1/2 h-1/2 md:h-full p-8 bg-neutral-950 flex items-center justify-center whitespace-nowrap">
+              <div className="max-[1020px]:w-full w-1/2 max-[1020px] h-1/2 md:h-full p-8 bg-neutral-950 flex items-center justify-center whitespace-nowrap">
                 <div className="max-w-lg animate-float">
                   <span className="text-neutral-400 tracking-wider text-sm font-mono">
                     {section.subtitle.split('\n').map((text, index) => (
@@ -164,7 +169,7 @@ function ScrollSections() {
                       </span>
                     ))}
                   </span>
-                  <h2 className="mt-4 leading-none bg-gradient-to-r from-white to-neutral-400 text-5xl md:text-7xl font-bold bg-clip-text text-transparent">
+                  <h2 className="mt-4 leading-none bg-gradient-to-r from-white to-neutral-400 text-6xl max-[1100px]:text-4xl font-bold bg-clip-text text-transparent">
                     {section.title.split('\n').map((text, index) => (
                       <span key={index}>
                         {text}
@@ -182,7 +187,7 @@ function ScrollSections() {
                   </p>
                 </div>
               </div>
-              <div className="group relative w-full md:w-1/2 h-1/2 md:h-full overflow-hidden before:content-[''] before:absolute before:top-0 before:left-0 before:w-full before:h-full before:bg-gradient-to-r before:from-neutral-950/70 before:to-neutral-950/50 before:transition-opacity before:duration-500 hover:before:opacity-0">
+              <div className="group relative max-[1020px]:w-full w-1/2 max-[1020px] h-1/2 md:h-full overflow-hidden before:content-[''] before:absolute before:top-0 before:left-0 before:w-full before:h-full before:bg-gradient-to-r before:from-neutral-950/70 before:to-neutral-950/50 before:transition-opacity before:duration-500 hover:before:opacity-0">
                 <Image
                   src={section.imageUrl}
                   alt={section.title}
@@ -212,9 +217,9 @@ function ScrollSections() {
       </div>
     </div>
   );
-}
+};
 
-function useIntersection(ref: React.RefObject<HTMLDivElement>) {
+const useIntersection = (ref: React.RefObject<HTMLDivElement>) => {
   const [isVisible, setIsVisible] = useState(false);
   const wasVisible = useRef(false);
 
@@ -236,9 +241,9 @@ function useIntersection(ref: React.RefObject<HTMLDivElement>) {
   }, [ref]);
 
   return isVisible;
-}
+};
 
-function ReviewCards() {
+const ReviewCards = () => {
   const ref = useRef<HTMLDivElement | null>(null);
   const isVisible = useIntersection(ref);
 
@@ -298,27 +303,29 @@ function ReviewCards() {
         </span>
       </div>
 
-      <div className="pt-20 flex gap-4">
+      <div className="pt-20 max-[560px]:pt-10 flex max-[560px]:flex-col gap-4">
         {reviews.map((review, index) => (
           <div
             key={review.id}
-            className={`w-[25%] h-[20rem] p-4 bg-black rounded-xl flex flex-col justify-between transition-all duration-1000 ease-out
-              ${index % 2 === 0 ? 'translate-y-4' : 'translate-y-24'}
+            className={`w-[25%] max-[560px]:w-full h-[20rem] max-[560px]:h-[12rem] p-4 bg-black rounded-xl flex flex-col justify-between transition-all duration-1000 ease-out
+              ${index % 2 === 0 ? 'translate-y-4 max-[560px]:translate-y-0' : 'translate-y-24 max-[560px]:translate-y-0'}
                   ${
                     isVisible
                       ? 'opacity-100 translate-y-0'
                       : 'opacity-0 translate-y-[20rem]'
                   }`}
           >
-            <div className="flex flex-col">
+            <div className="flex flex-col gap-2">
               <span className="text-gray-400">{review.rating}</span>
-              <span className="text-xl font-pretendard font-bold text-gray-300 hover:text-main transition duration-200 ease-in">
+              <span className="text-xl max-[690px]:text-lg max-[560px]:text-sm font-pretendard font-bold text-gray-300 hover:text-main transition duration-200 ease-in">
                 {review.content}
               </span>
             </div>
-            <div className="flex gap-2">
-              <span className="text-white text-xl">{review.imageUrl}</span>
-              <span className="text-main-light font-bold text-xl">
+            <div className="flex items-center gap-2">
+              <span className="text-white text-xl max-[690px]:text-sm">
+                {review.imageUrl}
+              </span>
+              <span className="text-main-light font-bold text-xl max-[690px]:text-sm max-[560px]:text-sm">
                 {review.user}
               </span>
             </div>
@@ -327,16 +334,16 @@ function ReviewCards() {
       </div>
     </div>
   );
-}
+};
 
-function Contactme() {
+const Contactme = () => {
   const ref = useRef<HTMLDivElement | null>(null);
   const isVisible = useIntersection(ref);
 
   return (
     <div
       ref={ref}
-      className={`${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-[15rem]'} w-full max-w-[80rem] mx-auto px-10 sm:px-16 md:px-20 lg:px-24 xl:px-32 flex flex-col gap-4 transition-all duration-1000 ease-out`}
+      className={`w-full max-w-[80rem] mx-auto px-10 sm:px-16 md:px-20 lg:px-24 xl:px-32 flex flex-col gap-4 ${isVisible ? 'translate-y-0 opacity-100' : 'translate-y-[15rem] opacity-0'} transition-all duration-1000 ease-out`}
     >
       <span className="bg-gradient-to-r from-white to-neutral-400 bg-clip-text text-5xl max-lg:text-4xl max-md:text-2xl max-sm:text-lg font-pretendard font-bold text-transparent max-lg:text-shadow-none">
         Contact me<span className="text-main">.</span>
@@ -344,25 +351,25 @@ function Contactme() {
       <div className="flex gap-6 justify-between">
         <div className="w-[50%] h-[10rem] p-4 rounded-xl bg-gray-800 flex flex-col justify-center">
           <div className="flex justify-between">
-            <span className="text-2xl font-pretendard font-bold text-white">
+            <span className="text-2xl max-[690px]:text-xl max-[560px]:text-xs font-pretendard font-bold text-white">
               피드백을 들려주세요
             </span>
             <button
               className="text-white"
               onClick={() => window.open('mailto:cwl64658@gmail.com', '_blank')}
             >
-              <span className="text-4xl font-pretendard font-bold text-white">
+              <span className="text-4xl max-[690px]:text-lg font-pretendard font-bold text-white">
                 ↗
               </span>
             </button>
           </div>
-          <span className="text-[1rem] font-bold text-main-light hover:text-gray-200 transition-colors duration-300">
+          <span className="text-[1rem] max-[690px]:text-sm max-[560px]:text-xs font-bold text-main-light hover:text-gray-200 transition-colors duration-300">
             cwl64658@gmail.com
           </span>
         </div>
         <div className="w-[50%] h-[10rem] p-4 bg-gray-800 rounded-xl flex flex-col justify-center">
           <div className="flex justify-between">
-            <span className="text-2xl font-pretendard font-bold text-white">
+            <span className="text-2xl max-[690px]:text-xl max-[560px]:text-xs font-pretendard font-bold text-white">
               유튜브 보기
             </span>
             <button
@@ -374,19 +381,19 @@ function Contactme() {
                 )
               }
             >
-              <span className="text-4xl font-pretendard font-bold text-white">
+              <span className="text-4xl max-[690px]:text-lg font-pretendard font-bold text-white">
                 ↗
               </span>
             </button>
           </div>
-          <span className="text-[1rem] font-bold text-main-light hover:text-gray-200 transition-colors duration-300">
+          <span className="text-[1rem] max-[690px]:text-sm max-[560px]:text-xs font-bold text-main-light hover:text-gray-200 transition-colors duration-300">
             카페 마스터즈를 어떻게 사용하는지 알려드려요
           </span>
         </div>
       </div>
     </div>
   );
-}
+};
 
 export default function Home() {
   return (
@@ -398,7 +405,7 @@ export default function Home() {
       </section>
 
       {/* 2nd Section 사용자들의 리뷰 카드 */}
-      <section className="w-full h-[60rem] pt-60 bg-gray-100">
+      <section className="w-full h-[60rem] max-[560px]:h-[70rem] max-[560px]:pt-20 pt-60 bg-gray-100">
         <ReviewCards />
       </section>
 

--- a/components/auth/shared/utils.ts
+++ b/components/auth/shared/utils.ts
@@ -1,0 +1,5 @@
+export const handleEmailValid = (email: string): boolean => {
+  const pattern =
+    /^\s*[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}\s*$/i;
+  return pattern.test(email);
+};

--- a/components/auth/signin/index.tsx
+++ b/components/auth/signin/index.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { useSigninMutation } from 'hooks/mutation/useSigninMutation';
 import { useResetPasswordMutation } from 'hooks/mutation/useResetPasswordMutation';
 import { signinWithKakao } from 'utils/supabase/signinWithKakao';
+import { handleEmailValid } from '../shared/utils';
 import {
   AuthFormCardStyle,
   AuthFormMentionStyle,
@@ -11,7 +12,7 @@ import {
   KakaoButtonStyle,
 } from 'utils/styles';
 import { SignProps } from 'app/auth/page';
-import { checkEmailValid } from 'utils/common';
+
 import UserForm from '../shared/user-form';
 import ResetpasswordForm from './resetpassword-form';
 
@@ -28,7 +29,7 @@ export default function Signin({ setViewAction }: SignProps) {
   const checkEmail = () => {
     let isValid = true;
 
-    if (!checkEmailValid(email)) {
+    if (!handleEmailValid(email)) {
       setEmailError('유효하지 않은 이메일 형식입니다.');
       isValid = false;
     } else setEmailError(null);

--- a/components/auth/signup/index.tsx
+++ b/components/auth/signup/index.tsx
@@ -9,7 +9,7 @@ import {
   AuthFormTitleStyle,
   KakaoButtonStyle,
 } from 'utils/styles';
-import { checkEmailValid } from 'utils/common';
+import { handleEmailValid } from '../shared/utils';
 import { SignProps } from 'app/auth/page';
 import UserForm from '../shared/user-form';
 import OtpForm from './otp-form';
@@ -28,7 +28,7 @@ export default function Signup({ setViewAction }: SignProps) {
   const checkEmail = () => {
     let isValid = true;
 
-    if (!checkEmailValid(email)) {
+    if (!handleEmailValid(email)) {
       setEmailError('유효하지 않은 이메일 형식입니다.');
       isValid = false;
     } else setEmailError(null);

--- a/components/layouts/sidebar/index.tsx
+++ b/components/layouts/sidebar/index.tsx
@@ -9,7 +9,6 @@ import {
   CollectedCafeFromSupabase,
 } from 'types/common';
 import { useInView } from 'react-intersection-observer';
-import { getSidebarStyle } from 'utils/styles';
 import dynamic from 'next/dynamic';
 import Header from './header';
 import Footer from './footer';
@@ -190,17 +189,19 @@ export default function Sidebar() {
   return (
     <nav className="relative flex items-center">
       <div
-        className={getSidebarStyle(isDarkTheme, isSubSidebarOpen)}
+        className={`z-10 relative w-screen h-screen max-w-[27rem] px-1 rounded-none shadow-xl shadow-main-shadow ${
+          isDarkTheme ? 'bg-main-dark text-white' : 'bg-gray-100'
+        } ${isSubSidebarOpen ? 'hidden sm:block' : ''}`}
         ref={containerRef}
       >
-        <div className="flex flex-col min-h-screen">
+        <div className="h-full flex flex-col">
           {/* 상단 */}
-          <section className="sticky top-0 z-10">
+          <section className="flex-none">
             <Header />
           </section>
 
           {/* 중단 */}
-          <section className="flex-1 min-h-0 overflow-y-auto">
+          <section className="flex-1 overflow-y-auto overflow-x-hidden">
             {isMainPage && <SidebarTabList />}
 
             <section className="px-8 sm:px-4">
@@ -283,7 +284,7 @@ export default function Sidebar() {
 
           {/* 하단 */}
           {isSearchResultPage && (
-            <section className="sticky bottom-0 z-10">
+            <section className="flex-none">
               <PageConverter
                 isDarkTheme={isDarkTheme}
                 handlePreviousPage={handlePreviousPage}
@@ -294,7 +295,11 @@ export default function Sidebar() {
             </section>
           )}
 
-          {isMainPage && <Footer />}
+          {isMainPage && (
+            <section className="flex-none">
+              <Footer />
+            </section>
+          )}
         </div>
       </div>
 

--- a/components/layouts/sidebar/shared/utils.ts
+++ b/components/layouts/sidebar/shared/utils.ts
@@ -7,9 +7,3 @@ export const handleCopyClick = async (param: string) => {
     alert('다시 시도해주세요.');
   }
 };
-
-export const checkEmailValid = (email: string): boolean => {
-  const pattern =
-    /^\s*[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}\s*$/i;
-  return pattern.test(email);
-};

--- a/components/layouts/sidebar/sub-sidebar/shared/location-grid.tsx
+++ b/components/layouts/sidebar/sub-sidebar/shared/location-grid.tsx
@@ -1,4 +1,4 @@
-import { handleCopyClick } from 'utils/common';
+import { handleCopyClick } from '../../shared/utils';
 import { FaCopy } from 'react-icons/fa6';
 import { IoLocation } from 'react-icons/io5';
 import Tooltip from 'components/shared/tooltip';

--- a/components/layouts/sidebar/sub-sidebar/shared/phone-grid.tsx
+++ b/components/layouts/sidebar/sub-sidebar/shared/phone-grid.tsx
@@ -1,4 +1,4 @@
-import { handleCopyClick } from 'utils/common';
+import { handleCopyClick } from '../../shared/utils';
 import { FaPhoneSquare } from 'react-icons/fa';
 import { FaCopy } from 'react-icons/fa6';
 import Tooltip from 'components/shared/tooltip';

--- a/utils/styles.ts
+++ b/utils/styles.ts
@@ -1,10 +1,3 @@
-export const getSidebarStyle = (
-  isDarkTheme: boolean,
-  isSubSidebarOpen: boolean,
-) => {
-  return `z-10 relative w-screen h-screen max-w-[27rem] px-1 rounded-none shadow-xl shadow-main-shadow ${isDarkTheme ? 'bg-main-dark text-white' : 'bg-gray-100'} ${isSubSidebarOpen ? 'hidden sm:block' : ''} flex flex-col justify-between overflow-x-hidden`;
-};
-
 export const getSubSidebarStyle = (
   isSubSidebarOpen: boolean,
   isDarkTheme: boolean,


### PR DESCRIPTION
<h2>랜딩 페이지 반응형 개선</h2>

<h2>유틸 함수 이동</h2>
전역 utils에서 사용되는 컴포넌트의 동일 레이어 shared 디렉토리에 utils.ts로 이동

<h2>사이드바 스크롤 해결</h2>
이제 상세 정보 페이지에서도 중단에만 스크롤바 범위가 지정됨