### PR TITLE
[Fix] 여러가지 업데이트

### DIFF
--- a/actions/userActions.ts
+++ b/actions/userActions.ts
@@ -1,6 +1,12 @@
 'use server';
 
 import { createServerSupabaseClient } from 'utils/supabase/server';
+import { PostgrestError } from '@supabase/supabase-js';
+
+function handleError(error: PostgrestError): void {
+  console.error(error);
+  throw new Error(error.message);
+}
 
 export async function getCurrentUserId(): Promise<string> {
   const supabase = await createServerSupabaseClient();
@@ -30,10 +36,7 @@ export async function getAdminUser(userId: string): Promise<boolean> {
     .eq('userId', trimmedUserId)
     .maybeSingle();
 
-  if (error) {
-    console.error('Supabase 에러:', error.message);
-    return false;
-  }
+  if (error) handleError(error);
 
   if (!data) {
     console.warn('admin이 아닌 사용자입니다.');

--- a/app/api/extra/[id]/route.ts
+++ b/app/api/extra/[id]/route.ts
@@ -90,7 +90,7 @@ export async function GET(
 
     return NextResponse.json(data);
   } catch (error) {
-    console.error('🚨 추출 오류 발생:', error);
+    console.error('상세 정보 fetch error:', error);
     return NextResponse.json(
       { error: 'Internal Server Error' },
       { status: 500 },

--- a/app/api/extra/product/[id]/route.ts
+++ b/app/api/extra/product/[id]/route.ts
@@ -93,7 +93,7 @@ export async function GET(
 
     return NextResponse.json(data);
   } catch (error) {
-    console.error('🚨 추출 중 오류 발생:', error);
+    console.error('상세 정보 fetch error:', error);
     return NextResponse.json(
       { error: 'Internal Server Error' },
       { status: 500 },

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -6,6 +6,8 @@ import Signin from 'components/auth/signin/index';
 import AuthBackgroundCards from 'components/auth/shared/background-cards';
 import Image from 'next/image';
 
+export const dynamic = 'force-static';
+
 export type AuthView = 'SIGNIN' | 'SIGNUP';
 
 export interface SignProps {

--- a/app/cafe/bookmarked/detail/[id]/page.tsx
+++ b/app/cafe/bookmarked/detail/[id]/page.tsx
@@ -1,27 +1,14 @@
 'use client';
 
-import { useEffect, use } from 'react';
-import { useMapStore, useCheckStore } from 'utils/store';
+import { use } from 'react';
 import { PageProps } from 'types/common';
 import Head from 'next/head';
+import useCafeDetailState from 'hooks/state/useCafeDetailState';
 
 export default function BookmarkedDetail({ params }: PageProps) {
   const { id } = use(params);
 
-  const bookmarkedCafe = useMapStore(state => state.bookmarkedCafe);
-  const setBookmarkedCafeDetail = useMapStore(
-    state => state.setBookmarkedCafeDetail,
-  );
-  const setIsBookmarked = useCheckStore(state => state.setIsBookmarked);
-
-  useEffect(() => {
-    const numericId = parseFloat(id);
-    const targetCafe = bookmarkedCafe.find(cafe => cafe.id === numericId);
-    if (targetCafe) {
-      setIsBookmarked(true);
-      setBookmarkedCafeDetail([targetCafe]);
-    }
-  }, [id, bookmarkedCafe, setBookmarkedCafeDetail, setIsBookmarked]);
+  useCafeDetailState(id, 'bookmarked');
 
   return (
     <Head>

--- a/app/cafe/collected/detail/[id]/page.tsx
+++ b/app/cafe/collected/detail/[id]/page.tsx
@@ -7,17 +7,14 @@ import Head from 'next/head';
 
 export default function CollectedDetail({ params }: PageProps) {
   const { id } = use(params);
+  const numericId = parseFloat(id);
 
-  const collectedCafe = useMapStore(state => state.collectedCafe);
-  const setCollectedCafeDetail = useMapStore(
-    state => state.setCollectedCafeDetail,
-  );
+  const { collectedCafe, setCollectedCafeDetail } = useMapStore();
 
   useEffect(() => {
-    const numericId = parseFloat(id);
     const targetCafe = collectedCafe.find(cafe => cafe.id === numericId);
     if (targetCafe) setCollectedCafeDetail([targetCafe]);
-  }, [id, collectedCafe, setCollectedCafeDetail]);
+  }, [id, numericId, collectedCafe, setCollectedCafeDetail]);
 
   return (
     <Head>

--- a/app/cafe/recommended/detail/[id]/page.tsx
+++ b/app/cafe/recommended/detail/[id]/page.tsx
@@ -1,55 +1,14 @@
 'use client';
 
-import { useEffect, use, useMemo } from 'react';
-import { useCheckStore, useMapStore } from 'utils/store';
+import { use } from 'react';
 import { PageProps } from 'types/common';
 import Head from 'next/head';
+import useCafeDetailState from 'hooks/state/useCafeDetailState';
 
 export default function RecommendedDetail({ params }: PageProps) {
   const { id } = use(params);
 
-  const collectedCafe = useMapStore(state => state.collectedCafe);
-  const bookmarkedCafe = useMapStore(state => state.bookmarkedCafe);
-  const recommendedCafe = useMapStore(state => state.recommendedCafe);
-  const setRecommendedCafeDetail = useMapStore(
-    state => state.setRecommendedCafeDetail,
-  );
-  const setIsBookmarked = useCheckStore(state => state.setIsBookmarked);
-  const setIsCollected = useCheckStore(state => state.setIsCollected);
-
-  const numericId = useMemo(() => parseFloat(id), [id]);
-
-  useEffect(() => {
-    setIsBookmarked(false);
-    setIsCollected(false);
-
-    const fetchFromStore = async () => {
-      try {
-        const targetCafe = recommendedCafe.find(cafe => cafe.id === numericId);
-        const isBookmarkedLocally = bookmarkedCafe.some(
-          cafe => cafe.id === numericId,
-        );
-        const isCollectedLocally = collectedCafe.some(
-          cafe => cafe.id === numericId,
-        );
-        if (targetCafe) setRecommendedCafeDetail([targetCafe]);
-        setIsCollected(isCollectedLocally);
-        setIsBookmarked(isBookmarkedLocally);
-      } catch (error) {
-        console.error(error);
-      }
-    };
-    fetchFromStore();
-  }, [
-    numericId,
-    bookmarkedCafe,
-    id,
-    recommendedCafe,
-    setIsBookmarked,
-    setRecommendedCafeDetail,
-    collectedCafe,
-    setIsCollected,
-  ]);
+  useCafeDetailState(id, 'recommended');
 
   return (
     <Head>

--- a/app/cafe/search/detail/[id]/page.tsx
+++ b/app/cafe/search/detail/[id]/page.tsx
@@ -1,76 +1,57 @@
 'use client';
 
-import { useEffect, use, useMemo } from 'react';
+import { useEffect, use } from 'react';
 import { useCheckStore, useMapStore, useUserStore } from 'utils/store';
 import { PageProps } from 'types/common';
 import Head from 'next/head';
 
 export default function SearchDetail({ params }: PageProps) {
   const { id } = use(params);
+  const numericId = parseFloat(id);
 
-  const bookmarkedCafe = useMapStore(state => state.bookmarkedCafe);
-  const collectedCafe = useMapStore(state => state.collectedCafe);
-  const recommendedCafe = useMapStore(state => state.recommendedCafe);
-  const setThisId = useMapStore(state => state.setThisId);
-  const setCafeDetail = useMapStore(state => state.setCafeDetail);
+  const {
+    bookmarkedCafe,
+    collectedCafe,
+    recommendedCafe,
+    setThisId,
+    setCafeDetail,
+  } = useMapStore();
   const userId = useUserStore(state => state.userId);
-  const setIsBookmarked = useCheckStore(state => state.setIsBookmarked);
-  const setIsCollected = useCheckStore(state => state.setIsCollected);
-  const setIsRecommended = useCheckStore(state => state.setIsRecommended);
-  const setIsLoading = useCheckStore(state => state.setIsLoading);
-
-  const numericId = useMemo(() => parseFloat(id), [id]);
-  const BASE_URL = useMemo(() => process.env.NEXT_PUBLIC_API_REQUEST_URI, []);
-
-  const REQ_URL =
-    BASE_URL === 'http://localhost:3000'
-      ? `/api/extra/${id}`
-      : `/api/extra/product/${id}`;
+  const { setIsBookmarked, setIsCollected, setIsRecommended, setIsLoading } =
+    useCheckStore();
 
   useEffect(() => {
     if (!userId || userId === '') return;
 
-    setIsLoading(true);
-    setIsBookmarked(false);
-    setIsCollected(false);
-    setIsRecommended(false);
+    const BASE_URL = process.env.NEXT_PUBLIC_API_REQUEST_URI;
 
-    const fetchFromStore = async () => {
-      try {
-        setThisId(numericId);
+    const REQ_URL =
+      BASE_URL === 'http://localhost:3000'
+        ? `/api/extra/${id}`
+        : `/api/extra/product/${id}`;
 
-        const isBookmarkedLocally = bookmarkedCafe.some(
-          cafe => cafe.id === numericId,
-        );
-        const isCollectedLocally = collectedCafe.some(
-          cafe => cafe.id === numericId,
-        );
-        const isRecommendedLocally = recommendedCafe.some(
-          cafe => cafe.id === numericId,
-        );
-        setIsBookmarked(isBookmarkedLocally);
-        setIsCollected(isCollectedLocally);
-        setIsRecommended(isRecommendedLocally);
-      } catch (error) {
-        console.error('수집한 카페와 북마크한 카페 중에서 찾지 못함:', error);
-      }
-    };
-
-    const fetchCafeDetail = async () => {
-      if (!BASE_URL) return;
+    const fetchData = async () => {
+      setIsLoading(true);
+      setIsBookmarked(false);
+      setIsCollected(false);
+      setIsRecommended(false);
 
       try {
         const response = await fetch(REQ_URL);
         const data = await response.json();
         setCafeDetail(data);
+        setThisId(numericId);
+        setIsBookmarked(bookmarkedCafe.some(cafe => cafe.id === numericId));
+        setIsCollected(collectedCafe.some(cafe => cafe.id === numericId));
+        setIsRecommended(recommendedCafe.some(cafe => cafe.id === numericId));
       } catch (error) {
-        console.error('카페 상세 정보 다운로드 에러:', error);
+        console.error('검색 결과 상세 정보 error:', error);
+      } finally {
+        setIsLoading(false);
       }
     };
 
-    Promise.all([fetchCafeDetail(), fetchFromStore()]).finally(() =>
-      setIsLoading(false),
-    );
+    fetchData();
   }, [
     id,
     userId,
@@ -78,8 +59,6 @@ export default function SearchDetail({ params }: PageProps) {
     bookmarkedCafe,
     collectedCafe,
     recommendedCafe,
-    BASE_URL,
-    REQ_URL,
     setThisId,
     setIsBookmarked,
     setIsCollected,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,10 +5,9 @@ import { useRouter } from 'next/navigation';
 import { useSigninMutation } from 'hooks/mutation/useSigninMutation';
 import Image from 'next/image';
 
-/**
- * 반응형 스타일 참고
- * @params 1100, 1020, 690, 560
- */
+export const dynamic = 'force-static';
+
+// 반응형 스타일 참고 1100, 1020, 690, 560
 
 const Navbar = () => {
   const router = useRouter();

--- a/app/resetpassword/complete/page.tsx
+++ b/app/resetpassword/complete/page.tsx
@@ -4,6 +4,8 @@ import { createBrowserSupabaseClient } from 'utils/supabase/client';
 import Head from 'next/head';
 import AuthBackgroundCards from 'components/auth/shared/background-cards';
 
+export const dynamic = 'force-static';
+
 export default function ResetPasswordComplete() {
   const supabase = createBrowserSupabaseClient();
 

--- a/app/resetpassword/page.tsx
+++ b/app/resetpassword/page.tsx
@@ -2,10 +2,12 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useFinishResetMutation } from 'hooks/mutation/useFinishResetMutation';
+import { useFinishResetPasswordMutation } from 'hooks/mutation/useFinishResetPasswordMutation';
 import { createBrowserSupabaseClient } from 'utils/supabase/client';
 import Head from 'next/head';
 import AuthBackgroundCards from 'components/auth/shared/background-cards';
+
+export const dynamic = 'force-static';
 
 export default function Resetpassword() {
   const supabase = createBrowserSupabaseClient();
@@ -15,7 +17,7 @@ export default function Resetpassword() {
 
   const router = useRouter();
 
-  const finishResetMutation = useFinishResetMutation();
+  const finishResetMutation = useFinishResetPasswordMutation();
 
   const handleSubmit = () => {
     finishResetMutation.mutate(newPassword);

--- a/components/auth/signin/index.tsx
+++ b/components/auth/signin/index.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import { useSigninMutation } from 'hooks/mutation/useSigninMutation';
-import { useResetPasswordMutation } from 'hooks/mutation/useResetPasswordMutation';
+import { useRequestResetPasswordMutation } from 'hooks/mutation/useRequestResetPasswordMutation';
 import { signinWithKakao } from 'utils/supabase/signinWithKakao';
 import { handleEmailValid } from '../shared/utils';
 import {
@@ -23,7 +23,7 @@ export default function Signin({ setViewAction }: SignProps) {
   const [resetRequested, setResetRequested] = useState<string>('');
 
   const signinMutation = useSigninMutation();
-  const resetPasswordMutation = useResetPasswordMutation();
+  const resetPasswordMutation = useRequestResetPasswordMutation();
 
   const handleEmail = () => {
     let isValid = true;
@@ -43,31 +43,12 @@ export default function Signin({ setViewAction }: SignProps) {
     }
   };
 
-  // const handleTestSignin = async () => {
-  //   try {
-  //     const response = await fetch('/api/auth/test-credential');
-  //     const data = await response.json();
-  //     if (!response.ok)
-  //       throw new Error(
-  //         data.error || '테스트 계정 정보를 불러오지 못했습니다.',
-  //       );
-
-  //     setEmail(data.email);
-  //     setPassword(data.password);
-  //     setTimeout(() => {
-  //       signinMutation.mutate({ email: data.email, password: data.password });
-  //     }, 0);
-  //   } catch (error) {
-  //     console.error(error);
-  //   }
-  // };
-
   const handleResetPassword = async () => {
     try {
       const message = await resetPasswordMutation.mutateAsync(email);
       setResetRequested(message);
     } catch (error) {
-      console.error(error);
+      console.error('비밀번호 재설정 이메일 요청 error', error);
     }
   };
 
@@ -97,15 +78,6 @@ export default function Signin({ setViewAction }: SignProps) {
               setPassword={setPassword}
             />
             <p className="text-red-500">{emailError}</p>
-            {/* <button
-              type="button"
-              data-cy="test-signin-button"
-              aria-label="체험 계정 로그인 버튼"
-              className="bg-orange-600 w-full py-1 hover:bg-opacity-70 hover:cursor-pointer"
-              onClick={() => handleTestSignin()}
-            >
-              <span className="font-dpixel text-white">체험하기</span>
-            </button> */}
             <button
               data-cy="signin-button"
               type="button"

--- a/components/layouts/sidebar/sub-sidebar/normal-cafe/normal-cafe-detail.tsx
+++ b/components/layouts/sidebar/sub-sidebar/normal-cafe/normal-cafe-detail.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useUploadBookmarkMutation } from 'hooks/mutation/useUploadBookmarkMutation';
-import { useCancelBookmarkMutation } from 'hooks/mutation/useCancelBookmarkMutation';
+import { useDeleteBookmarkMutation } from 'hooks/mutation/useDeleteBookmarkMutation';
 import { useCheckStore, useUserStore } from 'utils/store';
 import {
   NormalCafeDetailForBookmark,
@@ -48,7 +48,7 @@ export default function NormalCafeDetail({
   const pathname = usePathname();
 
   const uploadBookmarkMutation = useUploadBookmarkMutation();
-  const cancelBookmarkMutation = useCancelBookmarkMutation();
+  const deleteBookmarkMutation = useDeleteBookmarkMutation();
 
   const menu =
     !Array.isArray(detail?.menu) && detail?.menu
@@ -70,8 +70,8 @@ export default function NormalCafeDetail({
     toast.success('북마크 했습니다!');
   };
 
-  const handleCancelBookmark = () => {
-    cancelBookmarkMutation.mutate();
+  const handleDeleteBookmark = () => {
+    deleteBookmarkMutation.mutate(detail.id);
     setIsSubSidebarOpen(false);
     toast.success('북마크 취소했습니다!');
   };
@@ -107,8 +107,8 @@ export default function NormalCafeDetail({
           {isBookmarked ? (
             <button
               data-cy="cancel-bookmark-button"
-              aria-label="북마크 취소 버튼"
-              onClick={handleCancelBookmark}
+              aria-label="북마크 삭제 버튼"
+              onClick={handleDeleteBookmark}
               className="flex items-center"
             >
               <IoBookmark className="pr-2 text-yellow-500 text-3xl" />
@@ -130,7 +130,7 @@ export default function NormalCafeDetail({
           </span>
         </div>
         <button
-          aria-label="카페 상세 정보 보기 취소 버튼"
+          aria-label="상세 정보 닫기 버튼"
           onClick={handleSetIsSubSidebarOpen}
           className="px-2 right-2"
         >

--- a/components/layouts/sidebar/sub-sidebar/recommended-cafe/filter.tsx
+++ b/components/layouts/sidebar/sub-sidebar/recommended-cafe/filter.tsx
@@ -4,7 +4,6 @@ import { useMapStore } from 'utils/store';
 export default function Filter() {
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
 
-  // 1. 버튼용 카테고리 배열
   const categories = [
     '조용한',
     '시끌벅적한',
@@ -20,8 +19,6 @@ export default function Filter() {
     '빵 구운내 나는',
   ];
 
-  // 2. recommendedCafe의 각 카페에서, 선택한 카테고리를 &&으로 가진 카페만 filter
-  // 전역 상태로 공유되어야 함 -> 사이드바에서 normal-cafe를 매핑하기 때문에
   const recommendedCafe = useMapStore(state => state.recommendedCafe);
   const setFilteredRecommendedCafe = useMapStore(
     state => state.setFilteredRecommendedCafe,
@@ -36,9 +33,8 @@ export default function Filter() {
   };
 
   useEffect(() => {
-    // 3. filteredCafe를 렌더시키도록 useEffect 활용하기
     const filteredRecommendedCafe = recommendedCafe.filter(cafe => {
-      if (!cafe.category) return false; // 카테고리가 없으면 false
+      if (!cafe.category) return false;
       try {
         const parsedCategory = JSON.parse(cafe.category) as string[];
 
@@ -46,7 +42,7 @@ export default function Filter() {
           parsedCategory.includes(selected),
         );
       } catch (error) {
-        console.error('카테고리 파싱 오류:', error);
+        console.error('카테고리 parsing error:', error);
         return false;
       }
     });

--- a/hooks/mutation/useDeleteBookmarkMutation.ts
+++ b/hooks/mutation/useDeleteBookmarkMutation.ts
@@ -1,18 +1,16 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useMapStore, useUserStore } from 'utils/store';
+import { useUserStore } from 'utils/store';
 import { deleteBookmarkedCafe } from 'actions/bookmarkActions';
 
-export function useCancelBookmarkMutation() {
-  const bookmarkedCafeDetail = useMapStore(
-    state => state.bookmarkedCafeDetail[0],
-  );
+export function useDeleteBookmarkMutation() {
   const userId = useUserStore(state => state.userId);
 
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async () =>
-      await deleteBookmarkedCafe(bookmarkedCafeDetail?.id, userId),
+    mutationFn: async (cafeId: number) => {
+      return await deleteBookmarkedCafe(cafeId, userId);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['bookmarkedCafe', userId] });
       queryClient.invalidateQueries({

--- a/hooks/mutation/useFinishResetPasswordMutation.ts
+++ b/hooks/mutation/useFinishResetPasswordMutation.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { createBrowserSupabaseClient } from 'utils/supabase/client';
 
-export function useFinishResetMutation() {
+export function useFinishResetPasswordMutation() {
   const supabase = createBrowserSupabaseClient();
 
   return useMutation({

--- a/hooks/mutation/useRequestResetPasswordMutation.ts
+++ b/hooks/mutation/useRequestResetPasswordMutation.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { createBrowserSupabaseClient } from 'utils/supabase/client';
 
-export function useResetPasswordMutation() {
+export function useRequestResetPasswordMutation() {
   const supabase = createBrowserSupabaseClient();
 
   return useMutation({

--- a/hooks/state/useCafeDetailState.ts
+++ b/hooks/state/useCafeDetailState.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { useCheckStore, useMapStore } from 'utils/store';
+
+export default function useCafeDetailState(
+  id: string,
+  type: 'bookmarked' | 'recommended',
+) {
+  const numericId = parseFloat(id);
+
+  const {
+    bookmarkedCafe,
+    collectedCafe,
+    recommendedCafe,
+    setBookmarkedCafeDetail,
+    setRecommendedCafeDetail,
+  } = useMapStore();
+  const { setIsBookmarked, setIsCollected } = useCheckStore();
+
+  useEffect(() => {
+    const isCollected = collectedCafe.some(c => c.id === numericId);
+    const isBookmarked = bookmarkedCafe.some(c => c.id === numericId);
+
+    setIsCollected(isCollected);
+    setIsBookmarked(isBookmarked);
+
+    if (type === 'bookmarked') {
+      const target = bookmarkedCafe.find(c => c.id === numericId);
+      if (target) setBookmarkedCafeDetail([target]);
+    } else if (type === 'recommended') {
+      const target = recommendedCafe.find(c => c.id === numericId);
+      if (target) setRecommendedCafeDetail([target]);
+    }
+  }, [
+    numericId,
+    bookmarkedCafe,
+    collectedCafe,
+    recommendedCafe,
+    id,
+    setIsCollected,
+    setIsBookmarked,
+    type,
+    setBookmarkedCafeDetail,
+    setRecommendedCafeDetail,
+  ]);
+}


### PR DESCRIPTION
<h2>에러 메세지 코멘트 수정</h2>
실제 error 이전에 ' ' 문자열 마지막에 한글 에러 대신 영문 error로 변경

<h2>카페 상세 정보(북마크, 추천) 로직을 커스텀 훅으로 분리</h2>
useCafeDetailState에 type 리터럴을 파라미터로 같이 받아 북마크와 추천 카페 페이지 구분

<h2>SSG 적용</h2>
/, /auth, /resetpassword, /resetpassword/complete

<h2>useDeleteBookmarkMutation</h2>
useCancelBookmarkMutation에서 삭제의 의미를 명확하게 하는 delete로 변경 <br/>
/recommended/detail에서 잘못된 id가 계속 전달되어 mutationFn에 직접 id 전달로 변경