### PR TITLE
[feat] pulse dot 추가 후 수집한 카드 스크롤 로딩에 적용, 서브 사이드바 로딩 컴포넌트 변경

### DIFF
--- a/components/layouts/sidebar/index.tsx
+++ b/components/layouts/sidebar/index.tsx
@@ -19,6 +19,7 @@ import Footer from './footer';
 import dynamic from 'next/dynamic';
 import Help from './main/help';
 import useThrottle from '@/hooks/handler/useThrottle';
+import PulseDot from './shared/pulse-dot';
 
 const SearchResultList = dynamic(() => import('./main/search-result'), {
   ssr: false,
@@ -281,11 +282,7 @@ export default function Sidebar() {
                     )}
                   </ul>
 
-                  {isFetchingNextCollectedPage && (
-                    <div className="fixed bottom-4 left-4">
-                      <Spinner width="w-4" height="h-4" border="border-4" />
-                    </div>
-                  )}
+                  {isFetchingNextCollectedPage && <PulseDot />}
 
                   <div ref={collectedRef} className="h-[2rem] w-[22rem]"></div>
                 </div>

--- a/components/layouts/sidebar/shared/pulse-dot.tsx
+++ b/components/layouts/sidebar/shared/pulse-dot.tsx
@@ -1,0 +1,9 @@
+export default function PulseDot() {
+  return (
+    <div className="w-full h-8 flex justify-center items-center gap-8 animate-pulse">
+      <div className="w-[1rem] h-[1rem] rounded-full bg-main"></div>
+      <div className="w-[1rem] h-[1rem] rounded-full bg-main"></div>
+      <div className="w-[1rem] h-[1rem] rounded-full bg-main"></div>
+    </div>
+  );
+}

--- a/components/layouts/sidebar/shared/spinner.tsx
+++ b/components/layouts/sidebar/shared/spinner.tsx
@@ -9,7 +9,7 @@ interface SpinnerProps {
 export default function Spinner({ width, height, border }: SpinnerProps) {
   return (
     <div
-      className={`${width} ${height} ${border} border-main border-r-main-shadow border-b-main-light border-t-transparent rounded-full animate-spin`}
+      className={`${width} ${height} ${border} border-main border-t-transparent rounded-full animate-spin`}
     ></div>
   );
 }

--- a/components/layouts/sidebar/sub-sidebar/shared/loading.tsx
+++ b/components/layouts/sidebar/sub-sidebar/shared/loading.tsx
@@ -3,13 +3,9 @@ import { getDetailBodyStyle, getDetailHeaderStyle } from 'utils/styles';
 import { IoMdClock } from 'react-icons/io';
 import { IoBookmark, IoLocation, IoCloseCircle } from 'react-icons/io5';
 import { FaPhoneSquare } from 'react-icons/fa';
-import { FaCopy } from 'react-icons/fa6';
 import dynamic from 'next/dynamic';
 
 const Spinner = dynamic(() => import('../../shared/spinner'), {
-  ssr: false,
-});
-const Skeleton = dynamic(() => import('./skeleton'), {
   ssr: false,
 });
 
@@ -19,11 +15,20 @@ export default function Loading() {
   return (
     <div className={`flex flex-col p-2 gap-4`}>
       <div className={getDetailHeaderStyle(isDarkTheme)}>
-        <div className="flex items-center">
+        <div className="flex items-end">
           <IoBookmark
             className={`pr-2 text-3xl ${isDarkTheme ? 'text-white' : ''}`}
           />
-          <p className="text-2xl font-semibold">로딩 중입니다...</p>
+          <span className="text-2xl font-semibold">로딩 중입니다</span>
+          <span className="w-[0.5rem] inline-block animate-[dotOne_1.5s_ease-in-out_infinite]">
+            .
+          </span>
+          <span className="w-[0.5rem] inline-block animate-[dotTwo_1.5s_ease-in-out_infinite]">
+            .
+          </span>
+          <span className="w-[0.5rem] inline-block animate-[dotThree_1.5s_ease-in-out_infinite]">
+            .
+          </span>
         </div>
         <div className="px-2 right-2">
           <IoCloseCircle className="text-main text-3xl hover:text-opacity-70" />
@@ -47,9 +52,7 @@ export default function Loading() {
               <IoMdClock />
               <p className="font-dpixel">영업시간</p>
             </div>
-            <div className="col-span-1 text-left">
-              <Skeleton width="w-[10rem]" height="h-[1rem]" />
-            </div>
+            <div className="col-span-1 text-left"></div>
           </div>
           <div className="col-span-2 grid grid-cols-3 items-center">
             <div className="col-span-1 flex items-center gap-1">
@@ -57,10 +60,7 @@ export default function Loading() {
               <p className="font-dpixel">위치</p>
             </div>
             <div className="col-span-2 flex items-center gap-4">
-              <Skeleton width="w-[10rem]" height="h-[1rem]" />
-              <div className="hover:opacity-70">
-                <FaCopy />
-              </div>
+              <div className="hover:opacity-70"></div>
             </div>
           </div>
           <div className="col-span-2 grid grid-cols-3 items-center">
@@ -69,10 +69,7 @@ export default function Loading() {
               <p className="font-dpixel">전화번호</p>
             </div>
             <div className="col-span-2 flex items-center gap-4">
-              <Skeleton width="w-[10rem]" height="h-[1rem]" />
-              <div className="hover:opacity-70">
-                <FaCopy />
-              </div>
+              <div className="hover:opacity-70"></div>
             </div>
           </div>
           <div className="col-span-2">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -117,6 +117,20 @@ const config: Config = {
       },
 
       keyframes: {
+        dotOne: {
+          '0%, 100%': { opacity: '0' },
+          '33%': { opacity: '1' },
+          '66%': { opacity: '1' },
+        },
+        dotTwo: {
+          '0%, 33%': { opacity: '0' },
+          '66%': { opacity: '1' },
+          '100%': { opacity: '1' },
+        },
+        dotThree: {
+          '0%, 66%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
         gradient: {
           '0%': {
             'background-position': '0% 50%',


### PR DESCRIPTION
- pulse dot을 추가함
- 서브 사이드바에 이상한 스켈레톤 제거해버리고 copy 아이콘도 제거하고 스피너 단색으로 통일하고 제목에 '...' 순차 펄스닷 적용