### PR TITLE
3 Commits: 검색 결과 상세 정보를 점진적 렌더링으로 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cafe Masters Ver 2
+# Cafe Masters Ver 2 (WIP)
 
 ![썸네일](https://github.com/user-attachments/assets/e042eb80-164e-4031-ba76-b3c129eea431)
 

--- a/app/search/detail/[id]/page.tsx
+++ b/app/search/detail/[id]/page.tsx
@@ -23,6 +23,6 @@ export async function generateMetadata({ searchParams }: ISearchDetailPage): Pro
   };
 }
 
-export default function SearchDetailPage(props: ISearchDetailPage) {
-  return <SearchDetailClient {...props} />;
+export default function SearchDetailPage({ params, searchParams }: ISearchDetailPage) {
+  return <SearchDetailClient params={params} searchParams={searchParams} />;
 }

--- a/components/search/detail/SearchCafeDetail.tsx
+++ b/components/search/detail/SearchCafeDetail.tsx
@@ -25,17 +25,21 @@ export default function SearchCafeDetail({ cafeId, setIsRecommendFormOpenAction 
   const setTargetCafeForRecommend = useRecommendationStore(state => state.setTargetCafeForRecommend);
   const setTargetCafeForCollect = useCollectionStore(state => state.setTargetCafeForCollect);
 
-  const { searchedCafeDetail } = useSearchedCafeDetail(cafeId.toString());
+  const { searchedCafeDetail, isLoading: isDetailLoading } = useSearchedCafeDetail(cafeId.toString());
 
+  // 즉시 렌더링: 검색 결과에 포함된 기본 정보(클라이언트 캐시)
+  const foundCafe = useMemo(() => {
+    const cafe = searchResult.find(cafe => Number(cafe.id) === cafeId);
+    if (!cafe) throw new Error('카페의 상세 정보를 찾을 수 없습니다');
+    return cafe;
+  }, [searchResult, cafeId]);
+
+  // 점진적 렌더링: 기본 정보 + 카페 상세 정보 데이터 업데이트(API 응답)
   const searchedDetail = useMemo(() => {
-    const foundCafe = searchResult.find(cafe => Number(cafe.id) === cafeId);
-
-    if (!foundCafe) throw new Error('카페의 상세 정보를 찾을 수 없습니다');
-
     return {
       id: foundCafe.id,
       name: foundCafe.place_name,
-      image: searchedCafeDetail?.image ?? 'https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters//cafe_thumbnail.avif',
+      image: searchedCafeDetail?.image || 'https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters//cafe_thumbnail.avif',
       address: foundCafe.road_address_name ?? foundCafe.address_name,
       phone_number: foundCafe.phone ?? '',
       kakaoCategories: foundCafe.category_name ? foundCafe.category_name.split(' > ') : [],
@@ -43,7 +47,7 @@ export default function SearchCafeDetail({ cafeId, setIsRecommendFormOpenAction 
       opening_time: searchedCafeDetail?.opening_time ?? null,
       menus: searchedCafeDetail?.menus ?? null,
     };
-  }, [searchResult, cafeId, searchedCafeDetail]);
+  }, [foundCafe, searchedCafeDetail]);
 
   const bookmarkData = {
     id: Number(searchedDetail.id),
@@ -105,14 +109,13 @@ export default function SearchCafeDetail({ cafeId, setIsRecommendFormOpenAction 
 
   return (
     <article className="h-full rounded-md flex flex-col">
-      <CafeDetailHeader
-        bookmarkData={bookmarkData}
-      />
+      <CafeDetailHeader bookmarkData={bookmarkData} />
       <CafeDetailBody
         cafeId={cafeId}
         cafeData={searchedDetail}
         actionButtons={actionButtons}
         useImageWithFallback={true}
+        isDetailLoading={isDetailLoading}
       />
     </article>
   );

--- a/components/search/detail/SearchDetailClient.tsx
+++ b/components/search/detail/SearchDetailClient.tsx
@@ -5,13 +5,18 @@ import { useCurrentCafeStore, useUserStore } from '@/stores';
 import { useBookmarkCafes } from '@/hooks/supabase/bookmark';
 import { useCollectionCafes } from '@/hooks/supabase/collection';
 import { useRecommendationCafes } from '@/hooks/supabase/recommendation/useRecommendationCafes';
-import { IPageParams } from '@/types/shared/page';
+
+interface ISearchDetailClientProps {
+  params: Promise<{ id: string }>;
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+}
 
 /** 검색 카페 상세 페이지 클라이언트 컴포넌트
  * @description 카페 ID 동기화 / 북마크, 수집, 추천된 건지 확인하고 상태 업데이트
  */
-export default function SearchDetailClient({ params }: IPageParams) {
+export default function SearchDetailClient({ params }: ISearchDetailClientProps) {
   const resolvedParams = use(params);
+
   const { id } = resolvedParams;
   const numericId = Number(id);
 
@@ -41,7 +46,6 @@ export default function SearchDetailClient({ params }: IPageParams) {
     const isBookmarked = bookmarkCafes.some(cafe => cafe.id === numericId);
     const isRecommended = recommendationCafes?.some(cafe => cafe.id === numericId) || false;
 
-    // 배치 업데이트로 한 번에 처리
     const updateStates = () => {
       setIsCollected(isCollected);
       setIsBookmarked(isBookmarked);

--- a/components/shared/sliding-drawer/CafeDetailBody.tsx
+++ b/components/shared/sliding-drawer/CafeDetailBody.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { RefObject, useRef, ReactNode } from 'react';
+import { useUIStore } from '@/stores';
 import { scrollThumbnails } from '@/utils/shared/detail';
 import { FolderCheck } from 'lucide-react';
 import Location from '@/components/shared/sliding-drawer/Location';
@@ -10,7 +11,6 @@ import Menus from '@/components/shared/sliding-drawer/Menus';
 import Categories from '@/components/shared/sliding-drawer/Categories';
 import ImageWithFallback from '@/components/shared/ImageWithFallback';
 import Image from 'next/image';
-import { useUIStore } from '@/stores';
 
 interface ICafeDetailBody {
   cafeId: number;
@@ -21,19 +21,21 @@ interface ICafeDetailBody {
     image: string;
     extra_images?: string[];
     opening_time?: string | null;
-    menus?: { name: string; price: string; }[];
+    menus?: { name: string; price: string; description?: string; }[] | null;
     categories?: string[];
     kakaoCategories?: string[];
   };
   actionButtons: ReactNode;
   useImageWithFallback?: boolean;
+  isDetailLoading?: boolean;
 }
 
 export default function CafeDetailBody({
   cafeId,
   cafeData,
   actionButtons,
-  useImageWithFallback = false
+  useImageWithFallback = false,
+  isDetailLoading = false
 }: ICafeDetailBody) {
   const isDarkTheme = useUIStore(state => state.isDarkTheme);
 
@@ -42,7 +44,7 @@ export default function CafeDetailBody({
   return (
     <main className="overflow-y-auto overflow-x-hidden p-4 flex flex-col gap-4 flex-1">
       {/* 카페 이미지 */}
-      {cafeData.image && (
+      {(cafeData.image || isDetailLoading) && (
         <section
           key={`${cafeId}-image-section`}
           className="relative shadow-sm shadow-main/10 rounded-md flex flex-col items-center gap-4">
@@ -60,74 +62,82 @@ export default function CafeDetailBody({
             ref={scrollRef}
             className="w-full max-w-full overflow-x-auto overflow-y-hidden flex gap-4 scrollbar-hide snap-x snap-mandatory"
           >
-            <div className="h-60 py-2 snap-center shrink-0">
-              <a
-                type="button"
-                aria-label="카페 이미지 클릭 시 카카오플레이스 이동"
-                onClick={() =>
-                  window.open(`http://place.map.kakao.com/${cafeId}`, '_blank')
-                }
-              >
-                {useImageWithFallback ? (
-                  <ImageWithFallback
-                    key={`${cafeId}-main-image`}
-                    alt="카페 썸네일"
-                    src={cafeData.image}
-                    fallbackSrc="https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters//cafe_thumbnail.avif"
-                    width={340}
-                    height={240}
-                    priority={true}
-                    className="slide-images"
-                  />
-                ) : (
-                  <Image
-                    key={`${cafeId}-main-image`}
-                    alt="카페 썸네일"
-                    src={cafeData.image}
-                    width={340}
-                    height={240}
-                    priority={true}
-                    className="slide-images"
-                  />
-                )}
-              </a>
-            </div>
-
-            {cafeData.extra_images?.map((photo, i) => (
-              <div
-                key={`${cafeId}-extra-${i}`}
-                className="h-60 py-2 snap-center shrink-0"
-              >
-                {useImageWithFallback ? (
-                  <ImageWithFallback
-                    key={`${cafeId}-extra-image-${i}`}
-                    alt="카페 썸네일"
-                    src={photo}
-                    fallbackSrc="https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters//cafe_thumbnail.avif"
-                    width={340}
-                    height={240}
-                    priority={true}
-                    onClick={() =>
-                      window.open(`http://place.map.kakao.com/${cafeId}`, '_blank')
-                    }
-                    className="slide-images"
-                  />
-                ) : (
-                  <Image
-                    key={`${cafeId}-extra-image-${i}`}
-                    alt="카페 썸네일"
-                    src={photo}
-                    width={340}
-                    height={240}
-                    priority={true}
-                    onClick={() =>
-                      window.open(`http://place.map.kakao.com/${cafeId}`, '_blank')
-                    }
-                    className="slide-images"
-                  />
-                )}
+            {isDetailLoading && !cafeData.image ? (
+              <div className="h-60 py-2 snap-center shrink-0">
+                <div className="w-[340px] h-[240px] bg-gray-200 dark:bg-gray-700 animate-pulse rounded-md" />
               </div>
-            ))}
+            ) : (
+              <>
+                <div className="h-60 py-2 snap-center shrink-0">
+                  <a
+                    type="button"
+                    aria-label="카페 이미지 클릭 시 카카오플레이스 이동"
+                    onClick={() =>
+                      window.open(`http://place.map.kakao.com/${cafeId}`, '_blank')
+                    }
+                  >
+                    {useImageWithFallback ? (
+                      <ImageWithFallback
+                        key={`${cafeId}-main-image-${cafeData.image}`}
+                        alt="카페 썸네일"
+                        src={cafeData.image}
+                        fallbackSrc="https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters//cafe_thumbnail.avif"
+                        width={340}
+                        height={240}
+                        priority={true}
+                        className="slide-images"
+                      />
+                    ) : (
+                      <Image
+                        key={`${cafeId}-main-image-${cafeData.image}`}
+                        alt="카페 썸네일"
+                        src={cafeData.image}
+                        width={340}
+                        height={240}
+                        priority={true}
+                        className="slide-images"
+                      />
+                    )}
+                  </a>
+                </div>
+
+                {cafeData.extra_images?.map((photo, i) => (
+                  <div
+                    key={`${cafeId}-extra-${i}`}
+                    className="h-60 py-2 snap-center shrink-0"
+                  >
+                    {useImageWithFallback ? (
+                      <ImageWithFallback
+                        key={`${cafeId}-extra-image-${i}`}
+                        alt="카페 썸네일"
+                        src={photo}
+                        fallbackSrc="https://vsemazasjbizehcambul.supabase.co/storage/v1/object/public/cafe%20masters//cafe_thumbnail.avif"
+                        width={340}
+                        height={240}
+                        priority={true}
+                        onClick={() =>
+                          window.open(`http://place.map.kakao.com/${cafeId}`, '_blank')
+                        }
+                        className="slide-images"
+                      />
+                    ) : (
+                      <Image
+                        key={`${cafeId}-extra-image-${i}`}
+                        alt="카페 썸네일"
+                        src={photo}
+                        width={340}
+                        height={240}
+                        priority={true}
+                        onClick={() =>
+                          window.open(`http://place.map.kakao.com/${cafeId}`, '_blank')
+                        }
+                        className="slide-images"
+                      />
+                    )}
+                  </div>
+                ))}
+              </>
+            )}
           </div>
 
           <button
@@ -176,7 +186,7 @@ export default function CafeDetailBody({
         )}
 
         {/* 운영시간 */}
-        <OpenTime opening_time={cafeData.opening_time ?? ''} />
+        <OpenTime opening_time={cafeData.opening_time ?? ''} isLoading={isDetailLoading} />
       </section>
 
       {/* 액션 버튼들 */}
@@ -185,7 +195,7 @@ export default function CafeDetailBody({
       </section>
 
       {/* 메뉴 */}
-      <Menus menus={cafeData.menus} isDarkTheme={isDarkTheme} />
+      <Menus menus={cafeData.menus} isDarkTheme={isDarkTheme} isLoading={isDetailLoading} />
     </main>
   );
 }

--- a/components/shared/sliding-drawer/Menus.tsx
+++ b/components/shared/sliding-drawer/Menus.tsx
@@ -5,11 +5,30 @@ interface IMenus {
         name: string;
         price: string;
         description?: string;
-    }>;
+    }> | null;
     isDarkTheme: boolean;
+    isLoading?: boolean;
 }
 
-export default function Menus({ menus, isDarkTheme }: IMenus) {
+export default function Menus({ menus, isDarkTheme, isLoading = false }: IMenus) {
+    if (isLoading && (!menus || menus.length === 0)) {
+        return (
+            <div className="w-full">
+                <div className="w-full h-12 bg-gray-200 dark:bg-gray-700 animate-pulse rounded-lg mb-4" />
+                <div className="flex flex-col gap-3">
+                    {[1, 2, 3].map((i) => (
+                        <div key={i} className="p-3 shadow-md rounded-lg">
+                            <div className="flex justify-between items-start">
+                                <div className="h-5 bg-gray-200 dark:bg-gray-700 animate-pulse rounded w-24" />
+                                <div className="h-5 bg-gray-200 dark:bg-gray-700 animate-pulse rounded w-16" />
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        );
+    }
+
     if (!menus || menus.length === 0) {
         return (
             <div className="w-full p-4 text-center text-description">

--- a/components/shared/sliding-drawer/OpenTime.tsx
+++ b/components/shared/sliding-drawer/OpenTime.tsx
@@ -1,6 +1,11 @@
 import { Clock1 } from 'lucide-react';
 
-export default function OpenTime({ opening_time }: { opening_time: string | null }) {
+interface IOpenTime {
+  opening_time: string | null;
+  isLoading?: boolean;
+}
+
+export default function OpenTime({ opening_time, isLoading = false }: IOpenTime) {
   return (
     <div className="col-span-2 grid grid-cols-3">
       <div className="col-span-1 flex gap-1 items-center">
@@ -8,7 +13,11 @@ export default function OpenTime({ opening_time }: { opening_time: string | null
         <p className="">영업시간</p>
       </div>
       <div className="col-span-1 text-left">
-        <p>{opening_time}</p>
+        {isLoading && !opening_time ? (
+          <div className="h-5 bg-gray-200 dark:bg-gray-700 animate-pulse rounded" />
+        ) : (
+          <p>{opening_time}</p>
+        )}
       </div>
     </div>
   );

--- a/components/shared/sliding-drawer/SlidingDrawer.tsx
+++ b/components/shared/sliding-drawer/SlidingDrawer.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useState, Suspense } from 'react';
+import { useState } from 'react';
 import { useCurrentCafeStore, useUIStore } from '@/stores';
 import { usePathMatcher } from '@/hooks/ui/usePathMatcher';
 import clsx from 'clsx';
 import SearchCafeDetail from '@/components/search/detail/SearchCafeDetail';
-import CafeDetailSkeleton from '@/components/shared/sliding-drawer/CafeDetailSkeleton';
 import CollectionCafeDetail from '@/components/collection/detail/CollectionCafeDetail';
 import BookmarkCafeDetail from '@/components/bookmark/detail/BookmarkCafeDetail';
 import RecommendationCafeDetail from '@/components/recommendation/detail/RecommendationCafeDetail';
@@ -46,12 +45,12 @@ export default function SlidingDrawer() {
         }
 
         return (
-            <Suspense fallback={<CafeDetailSkeleton />}>
+            <>
                 {paths.isSearchDetail && <SearchCafeDetail cafeId={currentCafeId} setIsRecommendFormOpenAction={setIsRecommendFormOpenAction} />}
                 {paths.isCollectionDetail && <CollectionCafeDetail cafeId={currentCafeId} />}
                 {paths.isBookmarkDetail && <BookmarkCafeDetail cafeId={currentCafeId} />}
                 {paths.isRecommendationDetail && <RecommendationCafeDetail cafeId={currentCafeId} />}
-            </Suspense>
+            </>
         );
     };
 

--- a/hooks/kakao-map/useSearchedCafeDetail.ts
+++ b/hooks/kakao-map/useSearchedCafeDetail.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { ISearchedCafeDetail } from '@/types/kakao-map/kakao-map';
 import { searchCafeQuery } from '@/queries/kakao-map/search';
 
@@ -9,7 +9,7 @@ import { searchCafeQuery } from '@/queries/kakao-map/search';
  * @returns 카페 상세 정보 데이터
  */
 export function useSearchedCafeDetail(cafeId: string) {
-  const { data, isError, error } = useSuspenseQuery({
+  const { data, isError, error, isLoading } = useQuery({
     queryKey: searchCafeQuery.all(cafeId),
     queryFn: async (): Promise<ISearchedCafeDetail> => {
       const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
@@ -37,5 +37,5 @@ export function useSearchedCafeDetail(cafeId: string) {
     },
   });
 
-  return { searchedCafeDetail: data, isError, error };
+  return { searchedCafeDetail: data, isError, error, isLoading };
 }


### PR DESCRIPTION
## 📌 [refactor] 검색 결과 상세 정보를 점진적 렌더링으로 변경
- useSuspenseQuery와 Suspense를 사용하여 페칭 완료 전까지 모든 정보를 스켈레톤으로 막고 있었음
- 사용자 경험에 더 안 좋은거 같아서 useQuery를 사용하면서, searchResult의 값은 바로 UI에 동기화하고 나머지 이미지, 영업시간 등은 점진적 렌더링